### PR TITLE
[init] #16 GlobalExceptionHandler 설정

### DIFF
--- a/src/main/java/com/ggang/be/api/common/ApiResponse.java
+++ b/src/main/java/com/ggang/be/api/common/ApiResponse.java
@@ -3,12 +3,7 @@ package com.ggang.be.api.common;
 import lombok.Getter;
 
 @Getter
-public class  ApiResponse<T> {
-    private final boolean success;
-    private final int code;
-    private final String message;
-    private final T data;
-
+public record ApiResponse<T>(boolean success, int code, String message, T data) {
     public static <T> ApiResponse<T> success(ResponseSuccess responseSuccess, T data) {
         return new ApiResponse<>(true, responseSuccess.getCode(), responseSuccess.getMessage(), data);
     }
@@ -17,14 +12,8 @@ public class  ApiResponse<T> {
         return new ApiResponse<>(true, responseSuccess.getCode(), responseSuccess.getMessage(), null);
     }
 
-    public static <T> ApiResponse <T> error(ResponseError responseError) {
+    public static <T> ApiResponse<T> error(ResponseError responseError) {
         return new ApiResponse<>(false, responseError.getCode(), responseError.getMessage(), null);
     }
 
-    public ApiResponse(boolean success, int code, String message, T data) {
-        this.success = success;
-        this.code = code;
-        this.message = message;
-        this.data = data;
-    }
 }

--- a/src/main/java/com/ggang/be/api/common/ApiResponse.java
+++ b/src/main/java/com/ggang/be/api/common/ApiResponse.java
@@ -13,6 +13,10 @@ public class  ApiResponse<T> {
         return new ApiResponse<>(true, responseSuccess.getCode(), responseSuccess.getMessage(), data);
     }
 
+    public static <T> ApiResponse<T> success(ResponseSuccess responseSuccess) {
+        return new ApiResponse<>(true, responseSuccess.getCode(), responseSuccess.getMessage(), null);
+    }
+
     public static <T> ApiResponse <T> error(ResponseError responseError) {
         return new ApiResponse<>(false, responseError.getCode(), responseError.getMessage(), null);
     }

--- a/src/main/java/com/ggang/be/api/common/ApiResponse.java
+++ b/src/main/java/com/ggang/be/api/common/ApiResponse.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public class  ApiResponse<T> {
-    boolean success;
-    int code;
-    String message;
-    T data;
+    private final boolean success;
+    private final int code;
+    private final String message;
+    private final T data;
 
     public static <T> ApiResponse<T> success(ResponseSuccess responseSuccess, T data) {
         return new ApiResponse<>(true, responseSuccess.getCode(), responseSuccess.getMessage(), data);

--- a/src/main/java/com/ggang/be/api/common/PracticeController.java
+++ b/src/main/java/com/ggang/be/api/common/PracticeController.java
@@ -3,18 +3,24 @@ package com.ggang.be.api.common;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static com.ggang.be.api.common.ResponseError.*;
 
 @RestController
 public class PracticeController {
 
-    @GetMapping("/success")
-    public ResponseEntity<ApiResponse<String>> success() {
-        return ResponseBuilder.ok("1");
+    @GetMapping("/ok")
+    public ResponseEntity<ApiResponse<String>> ok() {
+        return ResponseBuilder.ok(null);
     }
 
-    @GetMapping("/custom_error")
+    @GetMapping("/created")
+    public ResponseEntity<ApiResponse<String>> created() {
+        return ResponseBuilder.created("1");
+    }
+
+    @GetMapping("/error")
     public ResponseEntity<ApiResponse<Void>> error() {
-        return ResponseBuilder.badRequest();
+        return ResponseBuilder.error(INVALID_TOKEN);
     }
 
 }

--- a/src/main/java/com/ggang/be/api/common/PracticeController.java
+++ b/src/main/java/com/ggang/be/api/common/PracticeController.java
@@ -18,7 +18,7 @@ public class PracticeController {
         return ResponseBuilder.created("1");
     }
 
-    @GetMapping("/error")
+    @GetMapping("/custom-error")
     public ResponseEntity<ApiResponse<Void>> error() {
         return ResponseBuilder.error(INVALID_TOKEN);
     }

--- a/src/main/java/com/ggang/be/api/common/PracticeController.java
+++ b/src/main/java/com/ggang/be/api/common/PracticeController.java
@@ -9,12 +9,12 @@ import static com.ggang.be.api.common.ResponseError.*;
 public class PracticeController {
 
     @GetMapping("/ok")
-    public ResponseEntity<ApiResponse<String>> ok() {
+    public ResponseEntity<ApiResponse<Object>> ok() {
         return ResponseBuilder.ok(null);
     }
 
     @GetMapping("/created")
-    public ResponseEntity<ApiResponse<String>> created() {
+    public ResponseEntity<ApiResponse<Object>> created() {
         return ResponseBuilder.created("1");
     }
 

--- a/src/main/java/com/ggang/be/api/common/ResponseBuilder.java
+++ b/src/main/java/com/ggang/be/api/common/ResponseBuilder.java
@@ -1,6 +1,5 @@
 package com.ggang.be.api.common;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public class ResponseBuilder {
@@ -8,7 +7,13 @@ public class ResponseBuilder {
     public static <T> ResponseEntity<ApiResponse<T>> ok(T data){
         return ResponseEntity.ok(ApiResponse.success(ResponseSuccess.OK, data));
     }
-    public static ResponseEntity<ApiResponse<Void>> badRequest() {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(ResponseError.BAD_REQUEST));
+
+    public static <T> ResponseEntity<ApiResponse<T>> created(T data){
+        return ResponseEntity.ok(ApiResponse.success(ResponseSuccess.CREATED, data));
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> error(ResponseError responseError) {
+        return ResponseEntity.status(responseError.getHttpStatus())
+                .body(ApiResponse.error(responseError));
     }
 }

--- a/src/main/java/com/ggang/be/api/common/ResponseError.java
+++ b/src/main/java/com/ggang/be/api/common/ResponseError.java
@@ -1,6 +1,7 @@
 package com.ggang.be.api.common;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ResponseError {
@@ -8,7 +9,7 @@ public enum ResponseError {
     // 400 Bad Request
     BAD_REQUEST(4000, "유효하지 않은 요청입니다."),
     INVALID_INPUT_VALUE(4001, "검증에 실패하였습니다."),
-    INVALID_INPUT_IMAGE_VALUE(4002, "지원하지 않는 이미지 확장자입니다."),
+    INVALID_INPUT_IMAGE_EXTENSION(4002, "지원하지 않는 이미지 확장자입니다."),
     INVALID_INPUT_IMAGE_SIZE(4003, "지원하지 않는 이미지 크기입니다."),
     INVALID_INPUT_IMAGE_URL(4004, "잘못된 이미지 URL 입니다."),
     INVALID_INPUT_LENGTH(4005, "글자수를 초과했습니다."),
@@ -44,5 +45,9 @@ public enum ResponseError {
     ResponseError(int code, String message) {
         this.code = code;
         this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.valueOf(code / 10);
     }
 }

--- a/src/main/java/com/ggang/be/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ggang/be/api/exception/GlobalExceptionHandler.java
@@ -1,8 +1,30 @@
 package com.ggang.be.api.exception;
 
+import com.ggang.be.api.common.ApiResponse;
+import com.ggang.be.api.common.ResponseBuilder;
+import com.ggang.be.api.common.ResponseError;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(GongBaekException.class)
+    public ResponseEntity<?> handleGlobalException(GongBaekException e) {
+        return ResponseBuilder.error(e.getResponseError());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+        return ResponseEntity
+                .status(ResponseError.BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.error(ResponseError.INVALID_INPUT_VALUE));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception e) {
+        return ResponseBuilder.error(ResponseError.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/src/main/java/com/ggang/be/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ggang/be/api/exception/GlobalExceptionHandler.java
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(GongBaekException.class)
-    public ResponseEntity<?> handleGlobalException(GongBaekException e) {
+    public ResponseEntity<ApiResponse<Void>> handleGlobalException(GongBaekException e) {
         return ResponseBuilder.error(e.getResponseError());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
         return ResponseEntity
                 .status(ResponseError.BAD_REQUEST.getHttpStatus())
                 .body(ApiResponse.error(ResponseError.INVALID_INPUT_VALUE));

--- a/src/main/java/com/ggang/be/api/exception/GongBaekException.java
+++ b/src/main/java/com/ggang/be/api/exception/GongBaekException.java
@@ -1,0 +1,14 @@
+package com.ggang.be.api.exception;
+
+import com.ggang.be.api.common.ResponseError;
+import lombok.Getter;
+
+@Getter
+public class GongBaekException extends RuntimeException {
+    private final ResponseError responseError;
+
+    public GongBaekException(ResponseError responseError) {
+        super(responseError.getMessage());
+        this.responseError = responseError;
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #16 

### 🎋 작업중인 브랜치
- init/#16

### 💡 작업내용
- GlobalExceptionHandler 설정

### 🔑 주요 변경사항
- GlobalExceptionHandler 설정
- ResponseBuilder 수정
```java
public static ResponseEntity<ApiResponse<Void>> error(ResponseError responseError) {
        return ResponseEntity.status(responseError.getHttpStatus())
                .body(ApiResponse.error(responseError));
    }
```
```java
public HttpStatus getHttpStatus() {
        return HttpStatus.valueOf(code / 10);
    }
```

인자 값을 통해 상태코드에 맞는 커스텀 에러를 반환할 수 있도록 설정했습니다.

### 🏞 스크린샷
스크린샷을 첨부해주세요.
<img width="711" alt="image" src="https://github.com/user-attachments/assets/5520576f-0a91-4d98-9d8b-c0c3f823de30" />

closes #16 
