### PR TITLE
[feat] 모임 정보 조회 API 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // valid
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ggang/be/api/common/ApiResponse.java
+++ b/src/main/java/com/ggang/be/api/common/ApiResponse.java
@@ -1,8 +1,5 @@
 package com.ggang.be.api.common;
 
-import lombok.Getter;
-
-@Getter
 public record ApiResponse<T>(boolean success, int code, String message, T data) {
     public static <T> ApiResponse<T> success(ResponseSuccess responseSuccess, T data) {
         return new ApiResponse<>(true, responseSuccess.getCode(), responseSuccess.getMessage(), data);

--- a/src/main/java/com/ggang/be/api/common/GroupResponse.java
+++ b/src/main/java/com/ggang/be/api/common/GroupResponse.java
@@ -1,0 +1,51 @@
+package com.ggang.be.api.common;
+
+import com.ggang.be.domain.constant.WeekDate;
+import lombok.Getter;
+
+@Getter
+public class GroupResponse {
+    private long groupId;
+    private String groupType;
+    private String title;
+    private String location;
+    private boolean status;
+    private int currentPeopleCount;
+    private int maxPeopleCount;
+    private String introduction;
+    private String category;
+    private String weekDate;
+    private String weekDay;
+    private double startTime;
+    private double endTime;
+
+    public GroupResponse(
+            long groupId,
+            String groupType,
+            String title,
+            String location,
+            boolean status,
+            int currentPeopleCount,
+            int maxPeopleCount,
+            String introduction,
+            String category,
+            WeekDate weekDay,
+            String weekDate,
+            double startTime,
+            double endTime
+    ) {
+        this.groupId = groupId;
+        this.groupType = groupType;
+        this.title = title;
+        this.location = location;
+        this.status = status;
+        this.currentPeopleCount = currentPeopleCount;
+        this.maxPeopleCount = maxPeopleCount;
+        this.introduction = introduction;
+        this.category = category;
+        this.weekDay = weekDay.toString();
+        this.weekDate = weekDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/ggang/be/api/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GroupFacade.java
@@ -1,0 +1,25 @@
+package com.ggang.be.api.facade;
+
+import com.ggang.be.api.common.GroupResponse;
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.everyGroup.EveryGroupService;
+import com.ggang.be.domain.onceGroup.OnceGroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupFacade {
+
+    private final EveryGroupService everyGroupService;
+    private final OnceGroupService onceGroupService;
+
+    public GroupResponse getGroupInfo(String groupType, Long groupId) {
+        return switch (groupType.toUpperCase()) {
+            case "WEEKLY" -> everyGroupService.getEveryGroupDetail(groupId);
+            case "ONCE" -> onceGroupService.getOnceGroupDetail(groupId);
+            default -> throw new GongBaekException(ResponseError.BAD_REQUEST);
+        };
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/GroupController.java
+++ b/src/main/java/com/ggang/be/api/group/GroupController.java
@@ -1,0 +1,29 @@
+package com.ggang.be.api.group;
+
+import com.ggang.be.api.common.ApiResponse;
+import com.ggang.be.api.common.GroupResponse;
+import com.ggang.be.api.common.ResponseSuccess;
+import com.ggang.be.api.facade.GroupFacade;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+public class GroupController {
+    private final GroupFacade groupFacade;
+
+    public GroupController(GroupFacade groupFacade) {
+        this.groupFacade = groupFacade;
+    }
+
+    @GetMapping("/fill/info")
+    public ResponseEntity<ApiResponse<GroupResponse>> getGroupInfo(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestParam(value = "groupType") String groupType,
+            @RequestParam(value = "groupId") @Min(value = 1, message = "groupId는 양수여야 합니다.") long groupId
+    ) {
+        GroupResponse groupResponse = groupFacade.getGroupInfo(groupType, groupId);
+        return ResponseEntity.ok(ApiResponse.success(ResponseSuccess.OK, groupResponse));
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/everyGroup/controller/EveryGroupController.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/controller/EveryGroupController.java
@@ -1,0 +1,16 @@
+package com.ggang.be.api.group.everyGroup.controller;
+
+import com.ggang.be.domain.everyGroup.EveryGroupService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class EveryGroupController {
+    private final EveryGroupService everyGroupService;
+
+    public EveryGroupController(EveryGroupService everyGroupService){
+        this.everyGroupService = everyGroupService;
+    }
+
+}

--- a/src/main/java/com/ggang/be/api/group/onceGroup/controller/OnceGroupController.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/controller/OnceGroupController.java
@@ -1,0 +1,16 @@
+package com.ggang.be.api.group.onceGroup.controller;
+
+import com.ggang.be.domain.onceGroup.OnceGroupService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OnceGroupController {
+    private OnceGroupService onceGroupService;
+
+    public OnceGroupController(OnceGroupService onceGroupService) {
+        this.onceGroupService = onceGroupService;
+    }
+}
+

--- a/src/main/java/com/ggang/be/domain/constant/Category.java
+++ b/src/main/java/com/ggang/be/domain/constant/Category.java
@@ -1,5 +1,10 @@
 package com.ggang.be.domain.constant;
 
 public enum Category {
-
+    STUDY,
+    DINING,
+    EXERCISE,
+    PLAYING,
+    NETWORKING,
+    OTHERS
 }

--- a/src/main/java/com/ggang/be/domain/constant/Gender.java
+++ b/src/main/java/com/ggang/be/domain/constant/Gender.java
@@ -1,5 +1,6 @@
 package com.ggang.be.domain.constant;
 
 public enum Gender {
-
+    MAN,
+    WOMAN
 }

--- a/src/main/java/com/ggang/be/domain/constant/Mbti.java
+++ b/src/main/java/com/ggang/be/domain/constant/Mbti.java
@@ -1,4 +1,20 @@
 package com.ggang.be.domain.constant;
 
 public enum Mbti {
+    ISTJ,
+    ISFJ,
+    INFJ,
+    INTJ,
+    ISTP,
+    ISFP,
+    INFP,
+    INTP,
+    ESTP,
+    ESFP,
+    ENFP,
+    ENTP,
+    ESTJ,
+    ESFJ,
+    ENFJ,
+    ENTJ;
 }

--- a/src/main/java/com/ggang/be/domain/constant/Status.java
+++ b/src/main/java/com/ggang/be/domain/constant/Status.java
@@ -1,4 +1,11 @@
 package com.ggang.be.domain.constant;
 
 public enum Status {
+    RECRUITING,
+    RECRUITED,
+    CLOSED;
+
+    public boolean isActive() {
+        return this == RECRUITING;
+    }
 }

--- a/src/main/java/com/ggang/be/domain/constant/WeekDate.java
+++ b/src/main/java/com/ggang/be/domain/constant/WeekDate.java
@@ -1,4 +1,11 @@
 package com.ggang.be.domain.constant;
 
 public enum WeekDate {
+    MON,
+    TUE,
+    WED,
+    THU,
+    FRI,
+    SAT,
+    SUN;
 }

--- a/src/main/java/com/ggang/be/domain/everyGroup/EveryGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/everyGroup/EveryGroupEntity.java
@@ -7,20 +7,15 @@ import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.constant.WeekDate;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.userEveryGroup.UserEveryGroupEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+import lombok.Getter;
+
 import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+@Getter
 @Entity(name = "every_group")
 public class EveryGroupEntity extends BaseTimeEntity {
 

--- a/src/main/java/com/ggang/be/domain/everyGroup/EveryGroupRepository.java
+++ b/src/main/java/com/ggang/be/domain/everyGroup/EveryGroupRepository.java
@@ -1,0 +1,7 @@
+package com.ggang.be.domain.everyGroup;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EveryGroupRepository extends JpaRepository<EveryGroupEntity, Long> {
+
+}

--- a/src/main/java/com/ggang/be/domain/everyGroup/EveryGroupService.java
+++ b/src/main/java/com/ggang/be/domain/everyGroup/EveryGroupService.java
@@ -1,0 +1,40 @@
+package com.ggang.be.domain.everyGroup;
+
+import com.ggang.be.api.common.GroupResponse;
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EveryGroupService {
+    private final EveryGroupRepository everyGroupRepository;
+
+    public EveryGroupService(EveryGroupRepository everyGroupRepository) {
+        this.everyGroupRepository = everyGroupRepository;
+    }
+
+    public GroupResponse getEveryGroupDetail(final long groupId) {
+        EveryGroupEntity everyGroupEntity = findIdOrThrow(groupId);
+        return new GroupResponse(
+                everyGroupEntity.getId(),
+                "WEEKLY",
+                everyGroupEntity.getTitle(),
+                everyGroupEntity.getLocation(),
+                everyGroupEntity.getStatus().isActive(),
+                everyGroupEntity.getCurrentPeopleCount(),
+                everyGroupEntity.getMaxPeopleCount(),
+                everyGroupEntity.getIntroduction(),
+                everyGroupEntity.getCategory().toString(),
+                everyGroupEntity.getWeekDate(),
+                null,
+                everyGroupEntity.getStartTime(),
+                everyGroupEntity.getEndTime()
+        );
+    }
+
+    private EveryGroupEntity findIdOrThrow(final long groupId){
+        return everyGroupRepository.findById(groupId).orElseThrow(
+                () -> new GongBaekException(ResponseError.GROUP_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/com/ggang/be/domain/onceGroup/OnceGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/onceGroup/OnceGroupEntity.java
@@ -6,21 +6,15 @@ import com.ggang.be.domain.constant.Category;
 import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.userOnceGroup.UserOnceGroupEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+import lombok.Getter;
+
 import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-
+@Getter
 @Entity(name = "once_group")
 public class OnceGroupEntity extends BaseTimeEntity {
 

--- a/src/main/java/com/ggang/be/domain/onceGroup/OnceGroupRepository.java
+++ b/src/main/java/com/ggang/be/domain/onceGroup/OnceGroupRepository.java
@@ -1,0 +1,7 @@
+package com.ggang.be.domain.onceGroup;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OnceGroupRepository extends JpaRepository<OnceGroupEntity, Long> {
+
+}

--- a/src/main/java/com/ggang/be/domain/onceGroup/OnceGroupService.java
+++ b/src/main/java/com/ggang/be/domain/onceGroup/OnceGroupService.java
@@ -1,0 +1,40 @@
+package com.ggang.be.domain.onceGroup;
+
+import com.ggang.be.api.common.GroupResponse;
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OnceGroupService {
+    private final OnceGroupRepository onceGroupRepository;
+
+    public OnceGroupService(OnceGroupRepository onceGroupRepository) {
+        this.onceGroupRepository = onceGroupRepository;
+    }
+
+    public GroupResponse getOnceGroupDetail(final long groupId) {
+        OnceGroupEntity onceGroupEntity = findIdOrThrow(groupId);
+        return new GroupResponse(
+                onceGroupEntity.getId(),
+                "ONCE",
+                onceGroupEntity.getTitle(),
+                onceGroupEntity.getLocation(),
+                onceGroupEntity.getStatus().isActive(),
+                onceGroupEntity.getCurrentPeopleCount(),
+                onceGroupEntity.getMaxPeopleCount(),
+                onceGroupEntity.getIntroduction(),
+                onceGroupEntity.getCategory().toString(),
+                null,
+                onceGroupEntity.getGroupDate().toString(),
+                onceGroupEntity.getStartTime(),
+                onceGroupEntity.getEndTime()
+        );
+    }
+
+    private OnceGroupEntity findIdOrThrow(final long groupId){
+        return onceGroupRepository.findById(groupId).orElseThrow(
+                () -> new GongBaekException(ResponseError.GROUP_NOT_FOUND)
+        );
+    }
+}

--- a/src/test/java/com/ggang/be/GroupControllerTest.java
+++ b/src/test/java/com/ggang/be/GroupControllerTest.java
@@ -1,0 +1,118 @@
+package com.ggang.be;
+
+import com.ggang.be.api.common.GroupResponse;
+import com.ggang.be.api.common.ResponseSuccess;
+import com.ggang.be.api.facade.GroupFacade;
+import com.ggang.be.api.group.GroupController;
+import com.ggang.be.domain.constant.WeekDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GroupController.class)
+@DisplayName("🔍 GroupController 단위 테스트 (Spring Boot 3.4+)")
+public class GroupControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private GroupFacade groupFacade;
+
+    @InjectMocks
+    private GroupController groupController;
+
+    public GroupControllerTest() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(groupController).build();
+    }
+
+    @Test
+    @DisplayName("✅ 모임 정보 조회 - 성공 (WEEKLY)")
+    void getGroupInfoWeeklySuccess() throws Exception {
+        // Given
+        GroupResponse mockResponse = new GroupResponse(
+                1L,
+                "WEEKLY",
+                "스터디 모임",
+                "도서관",
+                true,
+                5,
+                10,
+                "스터디 모임입니다.",
+                "STUDY",
+                WeekDate.WED,
+                null,
+                10.5,
+                12.0
+        );
+
+        when(groupFacade.getGroupInfo("WEEKLY", 1L)).thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/fill/info")
+                        .header("Authorization", "Bearer mockToken")
+                        .param("groupType", "WEEKLY")
+                        .param("groupId", "1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(ResponseSuccess.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(ResponseSuccess.OK.getMessage()))
+                .andExpect(jsonPath("$.data.groupType").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.groupTitle").value("스터디 모임"));
+    }
+
+    @Test
+    @DisplayName("❌ 잘못된 groupId (0 이하)")
+    void getGroupInfoInvalidGroupId() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/fill/info")
+                        .header("Authorization", "Bearer mockToken")
+                        .param("groupType", "WEEKLY")
+                        .param("groupId", "0")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    @DisplayName("❌ 잘못된 groupType")
+    void getGroupInfoInvalidGroupType() throws Exception {
+        when(groupFacade.getGroupInfo(anyString(), anyLong()))
+                .thenThrow(new IllegalArgumentException("Invalid groupType: INVALID"));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/fill/info")
+                        .header("Authorization", "Bearer mockToken")
+                        .param("groupType", "INVALID")
+                        .param("groupId", "1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Invalid groupType: INVALID"));
+    }
+
+    @Test
+    @DisplayName("❌ Authorization 헤더 없음")
+    void getGroupInfoNoAuthorizationHeader() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/fill/info")
+                        .param("groupType", "WEEKLY")
+                        .param("groupId", "1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #21 

### 🎋 작업중인 브랜치
- feat/#21

### 💡 작업내용
- 모임 정보 조회 API 기능 개발

### 🔑 주요 변경사항
- 모임 정보 조회 API 기능 개발
- onceGroup 과 everyGroup을 파라미터를 통해 구분하여 각 테이블에서 조회하고 결과 반환
```json
{
	"success": true,
	"code": 2000,
	"message": "성공하였습니다.",
	"data": {
		"groupId": 1,
		"status": true,
		"isHost": true,
		"isApply": true,
		"currentPeopleCount" : 4,
		"maxPeopleCount" : 6,
		"category": "STUDY",
		"coverImg": 1,
		"groupType": "WEEKLY",
		"groupTitle": "공강팅",
		"weekDay": "MON",
		"weekDate": null,
		"startTime": 10.5,
		"endTime": 12,
		"location": "학교 정문",
		"introduction": "복학하고 친구가 없어요 ㅠㅠ 밥 먹을 사람?"
	}
}
```

### 🏞 스크린샷
스크린샷을 첨부해주세요.


closes #21 
