### PR TITLE
[feat] 닉네임 검증 api 구현 진행 

### DIFF
--- a/src/main/java/com/ggang/be/api/common/ResponseError.java
+++ b/src/main/java/com/ggang/be/api/common/ResponseError.java
@@ -13,6 +13,7 @@ public enum ResponseError {
     INVALID_INPUT_IMAGE_SIZE(4003, "지원하지 않는 이미지 크기입니다."),
     INVALID_INPUT_IMAGE_URL(4004, "잘못된 이미지 URL 입니다."),
     INVALID_INPUT_LENGTH(4005, "입력된 글자수가 허용된 범위를 벗어났습니다."),
+    INVALID_INPUT_NICKNAME(4006, "닉네임은 한글로만 입력 가능합니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED_ACCESS(4010, "리소스 접근 권한이 없습니다."),

--- a/src/main/java/com/ggang/be/api/facade/SignupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/SignupFacade.java
@@ -1,0 +1,20 @@
+package com.ggang.be.api.facade;
+
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.api.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SignupFacade {
+
+    private final UserService userService;
+
+    public void duplicateCheckNickname(final String nickname){
+        userService.duplicateCheckNickname(nickname);
+    }
+
+
+
+}

--- a/src/main/java/com/ggang/be/api/facade/SignupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/SignupFacade.java
@@ -1,6 +1,5 @@
 package com.ggang.be.api.facade;
 
-import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/ggang/be/api/user/NicknameValidator.java
+++ b/src/main/java/com/ggang/be/api/user/NicknameValidator.java
@@ -1,0 +1,21 @@
+package com.ggang.be.api.user;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.global.util.LengthValidator;
+import java.util.regex.Pattern;
+
+public class NicknameValidator {
+
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 8;
+    private static final Pattern koreanPattern = Pattern.compile("^[가-힣]+$");
+
+    public static void validate(String nickname){
+        if(!LengthValidator.rangelengthCheck(nickname, MIN_LENGTH, MAX_LENGTH))
+            throw new GongBaekException(ResponseError.INVALID_INPUT_LENGTH);
+        if(!koreanPattern.matcher(nickname).find())
+            throw new GongBaekException(ResponseError.INVALID_INPUT_NICKNAME);
+    }
+
+}

--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> validateIntroduction(@RequestBody final ValidIntroductionRequestDto dto) {
         if(LengthValidator.rangelengthCheck(dto.introduction(), INTRODUCTION_MIN_LENGTH, INTRODUCTION_MAX_LENGTH))
             return ResponseBuilder.ok(null);
-        return ResponseBuilder.error(ResponseError.INVALID_INPUT_LENGTH);
+        throw new GongBaekException(ResponseError.INVALID_INPUT_LENGTH);
     }
 
     @PostMapping("/user/validate/nickname")

--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -3,14 +3,19 @@ package com.ggang.be.api.user.controller;
 import com.ggang.be.api.common.ApiResponse;
 import com.ggang.be.api.common.ResponseBuilder;
 import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.api.facade.SignupFacade;
+import com.ggang.be.api.user.NicknameValidator;
 import com.ggang.be.api.user.dto.ValidIntroductionRequestDto;
 import com.ggang.be.global.util.LengthValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,13 +26,21 @@ public class UserController {
 
     private final static int INTRODUCTION_MIN_LENGTH = 20;
     private final static int INTRODUCTION_MAX_LENGTH = 100;
+    private final SignupFacade signupFacade;
 
 
-    @GetMapping("/user/introduction")
+    @GetMapping("/user/validate/introduction")
     public ResponseEntity<ApiResponse<Void>> validateIntroduction(@RequestBody final ValidIntroductionRequestDto dto) {
         if(LengthValidator.rangelengthCheck(dto.introduction(), INTRODUCTION_MIN_LENGTH, INTRODUCTION_MAX_LENGTH))
             return ResponseBuilder.ok(null);
         return ResponseBuilder.error(ResponseError.INVALID_INPUT_LENGTH);
+    }
+
+    @PostMapping("/user/validate/nickname")
+    public ResponseEntity<ApiResponse<Void>> validateNickname(@RequestParam final String nickname) {
+            NicknameValidator.validate(nickname);
+            signupFacade.duplicateCheckNickname(nickname);
+            return ResponseBuilder.ok(null);
     }
 
 }

--- a/src/main/java/com/ggang/be/api/user/service/UserService.java
+++ b/src/main/java/com/ggang/be/api/user/service/UserService.java
@@ -1,0 +1,6 @@
+package com.ggang.be.api.user.service;
+
+public interface UserService {
+    boolean duplicateCheckNickname(String nickname);
+
+}

--- a/src/main/java/com/ggang/be/domain/user/UserEntity.java
+++ b/src/main/java/com/ggang/be/domain/user/UserEntity.java
@@ -6,7 +6,6 @@ import com.ggang.be.domain.constant.Mbti;
 import com.ggang.be.domain.gongbaekTimeSlot.GongbaekTimeSlotEntity;
 import com.ggang.be.domain.lectureTimeSlot.LectureTimeSlotEntity;
 import com.ggang.be.domain.school.SchoolEntity;
-import com.ggang.be.domain.schoolMajor.SchoolMajorEntity;
 import com.ggang.be.domain.userEveryGroup.UserEveryGroupEntity;
 import com.ggang.be.domain.userOnceGroup.UserOnceGroupEntity;
 import jakarta.persistence.Column;
@@ -37,9 +36,7 @@ public class UserEntity extends BaseTimeEntity {
     @JoinColumn(name = "school_id")
     private SchoolEntity school;
 
-    @OneToOne
-    @JoinColumn(name = "school_major_id")
-    private SchoolMajorEntity schoolMajorEntity;
+    private String schoolMajorName;
 
     private int profileImg;
 

--- a/src/main/java/com/ggang/be/domain/user/UserEntity.java
+++ b/src/main/java/com/ggang/be/domain/user/UserEntity.java
@@ -13,12 +13,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.util.List;
 
 @Entity(name = "user")
+@Table(indexes = {
+    @Index(name="user_nickname_index", columnList = "nickname")
+})
 public class UserEntity extends BaseTimeEntity {
 
     @Id
@@ -36,6 +41,7 @@ public class UserEntity extends BaseTimeEntity {
     @JoinColumn(name = "school_id")
     private SchoolEntity school;
 
+    @Column(nullable = false)
     private String schoolMajorName;
 
     private int profileImg;

--- a/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
@@ -1,0 +1,27 @@
+package com.ggang.be.domain.user.application;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.api.user.service.UserService;
+import com.ggang.be.domain.user.infra.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+
+    @Override
+    public boolean duplicateCheckNickname(String nickname) {
+        log.info("nickname {}", nickname);
+        if(userRepository.existsUserEntitiesByNickname(nickname))
+            throw new GongBaekException(ResponseError.NICKNAME_ALREADY_EXISTS);
+        return true;
+    }
+
+}

--- a/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
@@ -7,10 +7,12 @@ import com.ggang.be.domain.user.infra.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/ggang/be/domain/user/infra/UserRepository.java
+++ b/src/main/java/com/ggang/be/domain/user/infra/UserRepository.java
@@ -1,0 +1,9 @@
+package com.ggang.be.domain.user.infra;
+
+import com.ggang.be.domain.user.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    boolean existsUserEntitiesByNickname(String name);
+}

--- a/src/test/java/com/ggang/be/api/user/NicknameValidatorTest.java
+++ b/src/test/java/com/ggang/be/api/user/NicknameValidatorTest.java
@@ -1,0 +1,45 @@
+package com.ggang.be.api.user;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NicknameValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"가나aa", "bb나다", " 가나", "\n가"})
+    @DisplayName("닉네임 검증 테스트 순수 한글 아닌 경우 - 실패케이스")
+    void 닉네임이_순수_한글이_아닌_경우(String name){
+        //when && then
+        Assertions.assertThatThrownBy(() -> NicknameValidator.validate(name))
+                .isInstanceOf(GongBaekException.class)
+                .hasMessageContaining("닉네임은 한글로만 입력 가능합니다.")
+                .hasFieldOrPropertyWithValue("responseError", ResponseError.INVALID_INPUT_NICKNAME);
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"가나다라마바사아자", "가"})
+    @DisplayName("닉네임 검증 테스트 길이가 맞지 않는 경우 - 실패케이스")
+    void 닉네임의_길이범위가_맞지않는_경우(String name){
+        //when && then
+        Assertions.assertThatThrownBy(() -> NicknameValidator.validate(name))
+            .isInstanceOf(GongBaekException.class)
+            .hasMessageContaining("입력된 글자수가 허용된 범위를 벗어났습니다.")
+            .hasFieldOrPropertyWithValue("responseError", ResponseError.INVALID_INPUT_LENGTH);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"가나다라마바사아", "가나"})
+    @DisplayName("닉네임 검증 테스트 길이가 맞지 않는 경우 - 성공케이스")
+    void 닉네임검증_통과의경우(String name){
+        //when && then
+        Assertions.assertThatCode(() -> NicknameValidator.validate(name))
+            .doesNotThrowAnyException();
+    }
+
+
+}

--- a/src/test/java/com/ggang/be/domain/user/application/UserServiceImplTest.java
+++ b/src/test/java/com/ggang/be/domain/user/application/UserServiceImplTest.java
@@ -1,0 +1,54 @@
+package com.ggang.be.domain.user.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.user.infra.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userServiceImpl;
+
+
+    @Test
+    @DisplayName("닉네임 중복 체크 테스트 - 통과")
+    void duplicateCheckNicknamePass() {
+        //given
+        String nickname = "이현진";
+        when(userRepository.existsUserEntitiesByNickname(nickname)).thenReturn(false);
+
+        //when
+        boolean result = userServiceImpl.duplicateCheckNickname(nickname);
+
+        //then
+        Assertions.assertThat(result).isTrue();
+    }
+
+     @Test
+     @DisplayName("닉네임 중복 체크 테스트 - 실패")
+     void duplicateCheckNicknameFail() {
+
+         //given
+         String nickname = "김효준";
+         when(userRepository.existsUserEntitiesByNickname(nickname)).thenReturn(true);
+
+         //when && then
+
+         Assertions.assertThatThrownBy(() -> userServiceImpl.duplicateCheckNickname(nickname))
+             .isInstanceOf(GongBaekException.class)
+             .hasMessageContaining("이미 존재하는 닉네임입니다.");
+     }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #31 

### 🎋 작업중인 브랜치
- feat/#31

### 💡 작업내용
- 닉네임 검증 api를 구현하였습니다. 
- 추가로 검증 관련 api url 명세서 수정에 따라 수정작업 함께 진행했습니다.
- 소개글 검증 api를 일관성 맞게 닉네임 검증 style 따라 예외 처리하도록 하였습니다.

### 🔑 주요 변경사항
- 명세서 달라짐에 따라 검증 api url 수정 진행
- 닉네임 검증 api 구현
- userEntity nickname 인덱싱 추가

### 🏞 스크린샷

### 한글 검증
![image](https://github.com/user-attachments/assets/b72657f5-fdb9-4fab-97e3-bcbcd5775136)

### 범위 검증(길이 짧은 경우)
![image](https://github.com/user-attachments/assets/cdb0e99c-e797-4a4e-b5dc-c7fad31bf474)

### 범위 검증(길이 긴 경우)
<img width="868" alt="image" src="https://github.com/user-attachments/assets/2de20d73-094b-44b9-aa3e-29d08355de75" />

### 중복 검사
<img width="873" alt="image" src="https://github.com/user-attachments/assets/fe14c16e-867a-4ca8-8e3d-4380818d2b95" />

### 닉네임 검증 테스트 진행

<img width="640" alt="image" src="https://github.com/user-attachments/assets/2df0d97e-eb1e-48be-bbe5-3583a008c9e6" />

### 서비스 테스트 진행

<img width="566" alt="image" src="https://github.com/user-attachments/assets/6190479e-9f57-4408-9739-572ab846b9a1" />



closes #31
