### PR TITLE
[fix] 댓글 조회 API (모임방 / 채우기)  작성자 관련 boolean 상태 던져줄 수 있도록 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/comment/controller/CommentController.java
+++ b/src/main/java/com/ggang/be/api/comment/controller/CommentController.java
@@ -34,8 +34,8 @@ public class CommentController {
 
     @GetMapping("/comments")
     public ResponseEntity<ApiResponse<ReadCommentResponse>> getComments(@RequestHeader("Authorization") final String token, @RequestParam boolean isPublic, @RequestBody final ReadCommentRequest dto){
-        jwtService.isValidToken(token);
-        return ResponseBuilder.ok(commentFacade.readComment(isPublic, dto));
+        Long userId = jwtService.parseTokenAndGetUserId(token);
+        return ResponseBuilder.ok(commentFacade.readComment(userId, isPublic, dto));
     }
 
 }

--- a/src/main/java/com/ggang/be/api/facade/CommentFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/CommentFacade.java
@@ -46,15 +46,16 @@ public class CommentFacade {
             onceGroupService.writeCommentInGroup(commentEntity, dto.groupId());
     }
 
-    public ReadCommentResponse readComment(final boolean isPublic, ReadCommentRequest dto) {
-        return ReadCommentResponse.of(readByCase(isPublic, dto));
+    public ReadCommentResponse readComment(Long userId, final boolean isPublic, ReadCommentRequest dto) {
+        UserEntity findUserEntity = userService.getUserById(userId);
+        return ReadCommentResponse.of(readByCase(findUserEntity, isPublic, dto));
     }
 
-    private ReadCommentGroup readByCase(boolean isPublic, ReadCommentRequest dto) {
+    private ReadCommentGroup readByCase(UserEntity userEntity, boolean isPublic, ReadCommentRequest dto) {
         if(dto.groupType() == GroupType.WEEKLY)
-            return everyGroupService.readCommentInGroup(isPublic, dto.groupId());
+            return everyGroupService.readCommentInGroup(userEntity, isPublic, dto.groupId());
         if(dto.groupType() == GroupType.ONCE)
-            return onceGroupService.readCommentInGroup(isPublic, dto.groupId());
+            return onceGroupService.readCommentInGroup(userEntity, isPublic, dto.groupId());
         throw new GongBaekException(ResponseError.BAD_REQUEST);
     }
 

--- a/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
@@ -24,7 +24,7 @@ public interface EveryGroupService {
 
     void writeCommentInGroup(CommentEntity commentEntity, final long groupId);
 
-    ReadCommentGroup readCommentInGroup(boolean commentEntity, final long groupId);
+    ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean commentEntity, final long groupId);
 
     Long registerEveryGroup(RegisterGroupServiceRequest serviceRequest,
         GongbaekTimeSlotEntity gongbaekTimeSlotEntity);

--- a/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
@@ -9,7 +9,6 @@ import com.ggang.be.domain.group.onceGroup.dto.ReadOnceGroup;
 import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.user.UserEntity;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface OnceGroupService {
@@ -25,7 +24,7 @@ public interface OnceGroupService {
 
     void writeCommentInGroup(CommentEntity commentEntity, final long groupId);
 
-    ReadCommentGroup readCommentInGroup(boolean isPublic, final long groupId);
+    ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean isPublic, final long groupId);
 
     Long registerOnceGroup(RegisterGroupServiceRequest serviceRequest,
         GongbaekTimeSlotEntity gongbaekTimeSlotEntity);

--- a/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
@@ -14,4 +14,6 @@ public interface UserEveryGroupService {
     ReadEveryGroup getMyAppliedGroups(UserEntity currentUser, boolean status);
 
     NearestEveryGroup getMyNearestEveryGroup(UserEntity currentUser);
+
+    void isValidCommentAccess(UserEntity userEntity,final long groupId);
 }

--- a/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
@@ -17,4 +17,6 @@ public interface UserOnceGroupService {
     NearestOnceGroup getMyNearestOnceGroup(UserEntity currentUser);
 
     List<UserOnceGroupEntity> readUserTIme(UserEntity findUserEntity);
+
+    void isValidCommentAccess(UserEntity userEntity, final long groupId);
 }

--- a/src/main/java/com/ggang/be/domain/group/GroupCommentVoMaker.java
+++ b/src/main/java/com/ggang/be/domain/group/GroupCommentVoMaker.java
@@ -4,6 +4,7 @@ import com.ggang.be.domain.comment.CommentEntity;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.group.vo.GroupCommentVo;
+import com.ggang.be.domain.user.UserEntity;
 import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -11,17 +12,17 @@ import org.springframework.stereotype.Component;
 @Component
 public class GroupCommentVoMaker {
 
-    public List<GroupCommentVo> makeByEveryGroup(List<CommentEntity> commentEntities, EveryGroupEntity everyGroupEntity) {
+    public List<GroupCommentVo> makeByEveryGroup(UserEntity userEntity, List<CommentEntity> commentEntities, EveryGroupEntity everyGroupEntity) {
         return commentEntities.stream()
             .sorted(Comparator.comparing(CommentEntity::getCreatedAt))
-            .map(c -> GroupCommentVo.ofEveryGroup(everyGroupEntity, c))
+            .map(c -> GroupCommentVo.ofEveryGroup(userEntity, everyGroupEntity, c))
             .toList();
     }
 
-    public List<GroupCommentVo> makeByOnceGroup(List<CommentEntity> commentEntities, OnceGroupEntity onceGroupEntity) {
+    public List<GroupCommentVo> makeByOnceGroup(UserEntity userEntity, List<CommentEntity> commentEntities, OnceGroupEntity onceGroupEntity) {
         return commentEntities.stream()
             .sorted(Comparator.comparing(CommentEntity::getCreatedAt))
-            .map(c -> GroupCommentVo.ofOnceGroup(onceGroupEntity, c))
+            .map(c -> GroupCommentVo.ofOnceGroup(userEntity, onceGroupEntity, c))
             .toList();
     }
 }

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
@@ -82,7 +82,7 @@ public class EveryGroupServiceImpl implements EveryGroupService {
     }
 
     @Override
-    public ReadCommentGroup readCommentInGroup(boolean isPublic, long groupId) {
+    public ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean isPublic, long groupId) {
 
         EveryGroupEntity everyGroupEntity = everyGroupRepository.findById(groupId)
                 .orElseThrow(() -> new GongBaekException(ResponseError.GROUP_NOT_FOUND));
@@ -93,7 +93,7 @@ public class EveryGroupServiceImpl implements EveryGroupService {
         int commentCount = commentEntities.size();
 
         List<GroupCommentVo> onceGroupCommentVos = groupCommentVoMaker.makeByEveryGroup(
-                commentEntities, everyGroupEntity);
+                userEntity, commentEntities, everyGroupEntity);
 
         return ReadCommentGroup.of(commentCount, onceGroupCommentVos);
 

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
@@ -16,16 +16,12 @@ import com.ggang.be.domain.group.onceGroup.infra.OnceGroupRepository;
 import com.ggang.be.domain.group.vo.GroupCommentVo;
 import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.user.UserEntity;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -86,7 +82,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     }
 
     @Override
-    public ReadCommentGroup readCommentInGroup(boolean isPublic, long groupId) {
+    public ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean isPublic, long groupId) {
 
         OnceGroupEntity onceGroupEntity = onceGroupRepository.findById(groupId)
                 .orElseThrow(() -> new GongBaekException(ResponseError.GROUP_NOT_FOUND));
@@ -96,7 +92,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
 
         int commentCount = commentEntities.size();
 
-        List<GroupCommentVo> onceGroupCommentVos = groupCommentVoMaker.makeByOnceGroup(
+        List<GroupCommentVo> onceGroupCommentVos = groupCommentVoMaker.makeByOnceGroup(userEntity,
                 commentEntities, onceGroupEntity);
 
         return ReadCommentGroup.of(commentCount, onceGroupCommentVos);

--- a/src/main/java/com/ggang/be/domain/group/vo/GroupCommentVo.java
+++ b/src/main/java/com/ggang/be/domain/group/vo/GroupCommentVo.java
@@ -7,29 +7,33 @@ import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.user.UserEntity;
 import java.time.format.DateTimeFormatter;
 
-public record GroupCommentVo(long groupId, GroupType groupType, long commentId, boolean isHost,
+public record GroupCommentVo(long groupId, GroupType groupType, long commentId,boolean isWriter, boolean isGroupHost,
                              String nickname, String body, String createdAt) {
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
 
 
     public static GroupCommentVo ofEveryGroup(
+        UserEntity nowUserEntity,
         EveryGroupEntity groupEntity, CommentEntity commentEntity) {
         UserEntity commentUserEntity = commentEntity.getUserEntity();
         Long creatorId = groupEntity.getUserEntity().getId();
 
         return new GroupCommentVo(groupEntity.getId(), GroupType.WEEKLY, commentEntity.getId(),
+            commentUserEntity.getId().equals(nowUserEntity.getId()),
             commentUserEntity.getId().equals(creatorId),
             commentUserEntity.getNickname(), commentEntity.getBody(),
             formatter.format(commentEntity.getCreatedAt()));
     }
 
     public static GroupCommentVo ofOnceGroup(
+        UserEntity nowUserEntity,
         OnceGroupEntity groupEntity, CommentEntity commentEntity) {
         UserEntity commentUserEntity = commentEntity.getUserEntity();
         Long creatorId = groupEntity.getUserEntity().getId();
 
         return new GroupCommentVo(groupEntity.getId(), GroupType.ONCE, commentEntity.getId(),
+            commentUserEntity.getId().equals(nowUserEntity.getId()),
             commentUserEntity.getId().equals(creatorId),
             commentUserEntity.getNickname(), commentEntity.getBody(),
             formatter.format(commentEntity.getCreatedAt()));

--- a/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
@@ -1,6 +1,8 @@
 package com.ggang.be.domain.userEveryGroup.application;
 
 
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.domain.constant.WeekDate;
 import com.ggang.be.domain.group.GroupVoMaker;
@@ -58,6 +60,15 @@ public class UserEveryGroupServiceImpl implements UserEveryGroupService {
         EveryGroupEntity nearestGroup = getNearestGroup(getGroupsByStatus(userEveryGroupEntities, true));
 
         return NearestEveryGroup.toDto(nearestGroup);
+    }
+
+    @Override
+    public void isValidCommentAccess(UserEntity userEntity, final long groupId) {
+        List<UserEveryGroupEntity> userEveryGroupEntities = userEveryGroupRepository.findAllByUserEntity(userEntity);
+
+        if(userEveryGroupEntities.stream().noneMatch(ue -> ue.getEveryGroupEntity().getId().equals(groupId)))
+            throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
+
     }
 
     private EveryGroupEntity getNearestGroup(List<EveryGroupEntity> groups) {

--- a/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
@@ -1,5 +1,7 @@
 package com.ggang.be.domain.userOnceGroup.application;
 
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.group.GroupVoMaker;
 import com.ggang.be.domain.group.dto.ReadOnceGroupMember;
@@ -10,14 +12,13 @@ import com.ggang.be.domain.userEveryGroup.dto.FillMember;
 import com.ggang.be.domain.userOnceGroup.UserOnceGroupEntity;
 import com.ggang.be.domain.userOnceGroup.dto.NearestOnceGroup;
 import com.ggang.be.domain.userOnceGroup.infra.UserOnceGroupRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,21 +39,23 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
     }
 
     @Override
-    public ReadOnceGroup getMyAppliedGroups(UserEntity currentUser, boolean status){
+    public ReadOnceGroup getMyAppliedGroups(UserEntity currentUser, boolean status) {
         List<UserOnceGroupEntity> userOnceGroupEntities = getMyOnceGroup(currentUser);
 
-        List<OnceGroupEntity> filteredGroups = getGroupsByStatus(userOnceGroupEntities, status).stream()
-                .filter(group -> !group.getUserEntity().getId().equals(currentUser.getId()))
-                .toList();
+        List<OnceGroupEntity> filteredGroups = getGroupsByStatus(userOnceGroupEntities,
+            status).stream()
+            .filter(group -> !group.getUserEntity().getId().equals(currentUser.getId()))
+            .toList();
 
         return ReadOnceGroup.of(groupVoMaker.makeOnceGroup(filteredGroups));
     }
 
     @Override
-    public NearestOnceGroup getMyNearestOnceGroup(UserEntity currentUser){
+    public NearestOnceGroup getMyNearestOnceGroup(UserEntity currentUser) {
         List<UserOnceGroupEntity> userOnceGroupEntities = getMyOnceGroup(currentUser);
 
-        OnceGroupEntity nearestGroup = getNearestGroup(getGroupsByStatus(userOnceGroupEntities, true));
+        OnceGroupEntity nearestGroup = getNearestGroup(
+            getGroupsByStatus(userOnceGroupEntities, true));
 
         return NearestOnceGroup.toDto(nearestGroup);
     }
@@ -62,32 +65,47 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
         return userOnceGroupRepository.findAllByUserEntity(findUserEntity);
     }
 
-    private OnceGroupEntity getNearestGroup(List<OnceGroupEntity> groups) {
-        return groups.stream()
-                .min(Comparator.comparing(OnceGroupEntity::getGroupDate))
-                .orElse(null);
+    @Override
+    public void isValidCommentAccess(UserEntity userEntity, long groupId) {
+        List<UserOnceGroupEntity> userOnceGroupEntities = userOnceGroupRepository.findAllByUserEntity(
+            userEntity);
+
+        if (userOnceGroupEntities.stream()
+            .noneMatch(ue -> ue.getOnceGroupEntity().getId() == groupId)) {
+            throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
+        }
+
     }
 
-    private List<UserOnceGroupEntity> getMyOnceGroup(UserEntity currentUser){
+    private OnceGroupEntity getNearestGroup(List<OnceGroupEntity> groups) {
+        return groups.stream()
+            .min(Comparator.comparing(OnceGroupEntity::getGroupDate))
+            .orElse(null);
+    }
+
+    private List<UserOnceGroupEntity> getMyOnceGroup(UserEntity currentUser) {
         return userOnceGroupRepository.findByUserEntity_id(currentUser.getId());
     }
 
-    private List<OnceGroupEntity> getGroupsByStatus(List<UserOnceGroupEntity> userOnceGroupEntities, boolean status) {
+    private List<OnceGroupEntity> getGroupsByStatus(List<UserOnceGroupEntity> userOnceGroupEntities,
+        boolean status) {
         return userOnceGroupEntities.stream()
-                .map(UserOnceGroupEntity::getOnceGroupEntity)
-                .filter(group -> filterByStatus(group, status))
-                .collect(Collectors.toList());
+            .map(UserOnceGroupEntity::getOnceGroupEntity)
+            .filter(group -> filterByStatus(group, status))
+            .collect(Collectors.toList());
     }
 
     private FillMember makeUserOnceFillMemberResponse(UserOnceGroupEntity ue) {
         OnceGroupEntity onceGroupEntity = ue.getOnceGroupEntity();
         UserEntity userEntity = ue.getUserEntity();
-        boolean isHost = onceGroupEntity.getUserEntity().getNickname().equals(userEntity.getNickname());
+        boolean isHost = onceGroupEntity.getUserEntity().getNickname()
+            .equals(userEntity.getNickname());
         return FillMember.of(userEntity, isHost);
     }
 
     private boolean filterByStatus(OnceGroupEntity group, boolean status) {
-        return (status && group.getStatus().isActive()) || (!status && group.getStatus().isClosed());
+        return (status && group.getStatus().isActive()) || (!status && group.getStatus()
+            .isClosed());
     }
 
 }

--- a/src/test/java/com/ggang/be/domain/group/GroupCommentVoFixture.java
+++ b/src/test/java/com/ggang/be/domain/group/GroupCommentVoFixture.java
@@ -14,6 +14,7 @@ public class GroupCommentVoFixture {
             GroupType.ONCE,
             commentId,
             true,
+            true,
             "TestUser",
             "This is a sample comment body.",
             now.format(formatter)
@@ -26,6 +27,7 @@ public class GroupCommentVoFixture {
             groupId,
             GroupType.WEEKLY,
             commentId,
+            true,
             true,
             "TestUser",
             "This is a sample comment body.",


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #53 

### 🎋 작업중인 브랜치
- feat/#53

### 💡 작업내용
- 댓글 조회 API (모임방 / 채우기)  작성자 관련 boolean 상태 던져줄 수 있도록 수정

### 🔑 주요 변경사항
- 작성자 관련하여 boolean 상태 던져줄 수 있도록 수정

### 🏞 스크린샷
스크린샷을 첨부해주세요.


### 댓글 조회 api 호출
![image](https://github.com/user-attachments/assets/3e919abf-32e1-4964-9ddd-3707162a80f2)

### 모임에 참가하고 있지 않을 때 반응!

### WEEKLY

![image](https://github.com/user-attachments/assets/59939c59-ec2e-4f8a-a48f-0dfd43dbbce8)


### ONCE

![image](https://github.com/user-attachments/assets/1c99649e-fb6f-4290-9c8c-0b60a0151260)


### 모임에 참가하고 있을 때

### WEEKLY
![image](https://github.com/user-attachments/assets/ee53df9b-f164-4468-bc0a-fe61bae15253)

### ONCE
![image](https://github.com/user-attachments/assets/1169ff04-b998-4d36-b688-936b12df3784)


closes #53 
