### PR TITLE
[feat] 참여 가능한 모임 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/ggang/be/api/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GroupFacade.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -191,7 +192,7 @@ public class GroupFacade {
     }
 
     private boolean checkGroupsLectureTimeSlot(UserEntity findUserEntity, double startTime, double endTime, WeekDate weekDate) {
-        return !lectureTimeSlotService.isActiveGroupsInLectureTimeSlot(findUserEntity, startTime, endTime, weekDate);
+        return lectureTimeSlotService.isActiveGroupsInLectureTimeSlot(findUserEntity, startTime, endTime, weekDate);
     }
 
     private NearestGroupResponse getNearestGroupFromDates(NearestEveryGroup nearestEveryGroup, NearestOnceGroup nearestOnceGroup) {
@@ -215,7 +216,7 @@ public class GroupFacade {
         return Stream.concat(
                         everyGroupResponses.stream().map(GroupVo::fromEveryGroup),
                         onceGroupResponses.stream().map(GroupVo::fromOnceGroup))
-                .sorted((group1, group2) -> group2.createdAt().compareTo(group1.createdAt()))
+                .sorted(Comparator.comparing(GroupVo::createdAt).reversed())
                 .collect(Collectors.toList()
                 );
     }

--- a/src/main/java/com/ggang/be/api/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GroupFacade.java
@@ -139,7 +139,14 @@ public class GroupFacade {
     public List<ActiveGroupsResponse> getFillGroups(long userId) {
         UserEntity currentUser = userService.getUserById(userId);
 
-        List<GroupVo> allGroups = getActiveGroups(currentUser);
+        List<EveryGroupVo> everyGroupResponses = getActiveEveryGroups(currentUser);
+        List<OnceGroupVo> onceGroupResponses = getActiveOnceGroups(currentUser);
+
+        List<GroupVo> allGroups = Stream.concat(
+                        everyGroupResponses.stream().map(GroupVo::fromEveryGroup),
+                        onceGroupResponses.stream().map(GroupVo::fromOnceGroup))
+                .sorted((group1, group2) -> group2.createdAt().compareTo(group1.createdAt()))
+                .toList();
 
         return allGroups.stream()
                 .filter(groupVo -> checkGroupsLectureTimeSlot(currentUser, groupVo.startTime(), groupVo.endTime(), groupVo.weekDate()))
@@ -147,15 +154,40 @@ public class GroupFacade {
                 .collect(Collectors.toList());
     }
 
-    private List<GroupVo> getActiveGroups(UserEntity currentUser) {
-        List<EveryGroupVo> everyGroupResponses = everyGroupService.getActiveEveryGroups(currentUser).groups();
-        List<OnceGroupVo> onceGroupResponses = onceGroupService.getActiveOnceGroups(currentUser).groups();
+    public List<ActiveGroupsResponse> getLatestGroups(long userId, GroupType groupType) {
+        UserEntity currentUser = userService.getUserById(userId);
 
-        return Stream.concat(
-                        everyGroupResponses.stream().map(GroupVo::fromEveryGroup),
-                        onceGroupResponses.stream().map(GroupVo::fromOnceGroup))
+        List<GroupVo> allGroups;
+        switch (groupType) {
+            case WEEKLY -> {
+                List<EveryGroupVo> everyGroupResponses = getActiveEveryGroups(currentUser);
+                allGroups = everyGroupResponses.stream()
+                        .map(GroupVo::fromEveryGroup)
+                        .collect(Collectors.toList());
+            }
+            case ONCE -> {
+                List<OnceGroupVo> onceGroupResponses = getActiveOnceGroups(currentUser);
+                allGroups = onceGroupResponses.stream()
+                        .map(GroupVo::fromOnceGroup)
+                        .collect(Collectors.toList());
+            }
+            default -> throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+
+        return allGroups.stream()
+                .filter(groupVo -> checkGroupsLectureTimeSlot(currentUser, groupVo.startTime(), groupVo.endTime(), groupVo.weekDate()))
                 .sorted((group1, group2) -> group2.createdAt().compareTo(group1.createdAt()))
-                .toList();
+                .limit(5)
+                .map(ActiveGroupsResponse::fromGroupVo)
+                .collect(Collectors.toList());
+    }
+
+    private List<EveryGroupVo> getActiveEveryGroups(UserEntity currentUser) {
+        return everyGroupService.getActiveEveryGroups(currentUser).groups();
+    }
+
+    private List<OnceGroupVo> getActiveOnceGroups(UserEntity currentUser) {
+        return onceGroupService.getActiveOnceGroups(currentUser).groups();
     }
 
     private boolean checkGroupsLectureTimeSlot(UserEntity findUserEntity, double startTime, double endTime, WeekDate weekDate) {

--- a/src/main/java/com/ggang/be/api/group/controller/GroupController.java
+++ b/src/main/java/com/ggang/be/api/group/controller/GroupController.java
@@ -9,6 +9,7 @@ import com.ggang.be.api.facade.GongbaekRequestFacade;
 import com.ggang.be.api.facade.GroupFacade;
 import com.ggang.be.api.group.dto.*;
 import com.ggang.be.domain.constant.FillGroupType;
+import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.group.dto.GroupVo;
 import com.ggang.be.global.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
@@ -92,6 +93,16 @@ public class GroupController {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
 
         return ResponseBuilder.ok(groupFacade.getFillGroups(userId));
+    }
+
+    @GetMapping("/group/latest")
+    public ResponseEntity<ApiResponse<List<ActiveGroupsResponse>>> getLatestGroups(
+            @RequestHeader("Authorization") final String accessToken,
+            @RequestParam("groupType") final GroupType groupType
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+
+        return ResponseBuilder.ok(groupFacade.getLatestGroups(userId, groupType));
     }
 
     @GetMapping("/group/my/participation")

--- a/src/main/java/com/ggang/be/domain/timslot/lectureTimeSlot/application/LectureTimeSlotServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/timslot/lectureTimeSlot/application/LectureTimeSlotServiceImpl.java
@@ -41,7 +41,7 @@ public class LectureTimeSlotServiceImpl implements LectureTimeSlotService {
 
     @Override
     public boolean isActiveGroupsInLectureTimeSlot(UserEntity findUserEntity, double startTime, double endTime, WeekDate weekDate) {
-        return lectureTimeSlotRepository.isInTime(startTime, endTime, findUserEntity, weekDate);
+        return lectureTimeSlotRepository.isPossibleTime(startTime, endTime, findUserEntity, weekDate);
     }
 
     @Override

--- a/src/main/java/com/ggang/be/domain/timslot/lectureTimeSlot/infra/LectureTimeSlotRepository.java
+++ b/src/main/java/com/ggang/be/domain/timslot/lectureTimeSlot/infra/LectureTimeSlotRepository.java
@@ -20,6 +20,18 @@ public interface LectureTimeSlotRepository extends JpaRepository<LectureTimeSlot
         ")")
     boolean isInTime(double startTime, double endTime, UserEntity userEntity, WeekDate weekDate);
 
+    @Query("SELECT CASE WHEN COUNT(l) > 0 THEN FALSE ELSE TRUE END " +
+            "FROM lecture_time_slot l " +
+            "WHERE l.userEntity = :userEntity " +
+            "AND l.weekDate = :weekDate " +
+            "AND (" +
+            "     (l.startTime <= :startTime AND l.endTime >= :startTime) " +
+            "  OR (l.startTime <= :endTime AND l.endTime >= :endTime) " +
+            "  OR (l.startTime >= :startTime AND l.endTime <= :endTime)" +
+            "  OR (l.startTime >= :startTime AND l.endTime >= :endTime)" +
+            ")")
+    boolean isPossibleTime(double startTime, double endTime, UserEntity userEntity, WeekDate weekDate);
+
 
     List<LectureTimeSlotEntity> findAllByUserEntity(UserEntity userEntity);
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #59 

### 🎋 작업중인 브랜치
- feat/#59

### 💡 작업내용
- 홈 화면의 참여 가능한 모임 조회 API

### 🔑 주요 변경사항
- 참여 가능한 모임 조회 API
- 파라미터 값에 따라 일회성 모임과 다회성 모임 구분하여 조회
- 내 공강시간표와 겹치면서 현재 모집중인 모임 조회
- 글 등록시간 기준으로 최신순 5개만 조회

### 🏞 스크린샷
<img width="887" alt="image" src="https://github.com/user-attachments/assets/b69c0e42-acb4-4571-90e1-a8e1e137f271" />

closes #59
