### PR TITLE
[fix] 내 강의 시간표 조회 API idx 값 던져주기

### DIFF
--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -14,6 +14,7 @@ import com.ggang.be.api.user.dto.ValidIntroductionRequest;
 import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.domain.user.dto.UserSchoolDto;
 import com.ggang.be.global.jwt.JwtService;
+import com.ggang.be.global.jwt.TokenVo;
 import com.ggang.be.global.util.LengthValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +62,12 @@ public class UserController {
         UserSchoolDto userSchoolDto = userService.getUserSchoolById(userId);
 
         return ResponseEntity.ok(ApiResponse.success(ResponseSuccess.OK, UserSchoolResponseDto.of(userSchoolDto)));
+    }
+
+    @PatchMapping("/reissue/token")
+    public ResponseEntity<ApiResponse<TokenVo>> reIssueToken(
+        @RequestHeader("Authorization") String refreshToken) {
+        return ResponseBuilder.ok(jwtService.reIssueToken(refreshToken));
     }
 
 }

--- a/src/main/java/com/ggang/be/domain/timslot/ReadCommonInvalidTimeVoMaker.java
+++ b/src/main/java/com/ggang/be/domain/timslot/ReadCommonInvalidTimeVoMaker.java
@@ -4,6 +4,7 @@ import com.ggang.be.domain.timslot.lectureTimeSlot.LectureTimeSlotEntity;
 import com.ggang.be.domain.timslot.vo.ReadCommonInvalidTimeVo;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,8 +13,17 @@ public class ReadCommonInvalidTimeVoMaker {
 
     public List<ReadCommonInvalidTimeVo> convertToCommonResponse(
         List<LectureTimeSlotEntity> lectureTimeSlotEntities) {
-        return lectureTimeSlotEntities.stream().map(ReadCommonInvalidTimeVo::fromLectureEntity)
-            .sorted(Comparator.comparing(ReadCommonInvalidTimeVo::weekDate)).toList();
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        return lectureTimeSlotEntities.stream()
+            .sorted(Comparator.comparing(LectureTimeSlotEntity::getWeekDate))
+            .map(entity -> makeReadCommonInvalidTimeVo(entity, atomicInteger))
+            .sorted(Comparator.comparing(ReadCommonInvalidTimeVo::idx)).toList();
+    }
+
+    private ReadCommonInvalidTimeVo makeReadCommonInvalidTimeVo(LectureTimeSlotEntity entity,
+        AtomicInteger atomicInteger) {
+        return ReadCommonInvalidTimeVo.fromLectureEntity(atomicInteger.getAndIncrement(),
+            entity);
     }
 
 

--- a/src/main/java/com/ggang/be/domain/timslot/vo/ReadCommonInvalidTimeVo.java
+++ b/src/main/java/com/ggang/be/domain/timslot/vo/ReadCommonInvalidTimeVo.java
@@ -4,14 +4,16 @@ import com.ggang.be.domain.constant.WeekDate;
 import com.ggang.be.domain.timslot.lectureTimeSlot.LectureTimeSlotEntity;
 
 public record ReadCommonInvalidTimeVo(
+    int idx,
     WeekDate weekDate,
     double startTime,
     double endTime
 ) {
 
     public static ReadCommonInvalidTimeVo fromLectureEntity(
+        int idx,
         LectureTimeSlotEntity lectureTimeSlotEntity) {
-        return new ReadCommonInvalidTimeVo(lectureTimeSlotEntity.getWeekDate(),
+        return new ReadCommonInvalidTimeVo(idx, lectureTimeSlotEntity.getWeekDate(),
             lectureTimeSlotEntity.getStartTime(), lectureTimeSlotEntity.getEndTime());
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #71 

### 🎋 작업중인 브랜치
- fix/#71

### 💡 작업내용
- 클라이언트의 요구에 따라 timeTable 보내줄 때 idx 값 포함해서 보내주도록 진행

### 🔑 주요 변경사항
- 응답에 idx 추가
- 추가로 merge 시 잘못 삭제되었던 controller 추가되었습니다.

### 🏞 스크린샷

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/81e8164f-14eb-421a-a620-d58b5af74943" />


closes #71 
