### PR TITLE
[fix] 같은 학교 검증 하는 과정 빠진 할당받았던 api 들에 추가하는 작업 진행

### DIFF
--- a/src/main/java/com/ggang/be/api/common/ResponseError.java
+++ b/src/main/java/com/ggang/be/api/common/ResponseError.java
@@ -14,6 +14,7 @@ public enum ResponseError {
     INVALID_INPUT_IMAGE_URL(4004, "잘못된 이미지 URL 입니다."),
     INVALID_INPUT_LENGTH(4005, "입력된 글자수가 허용된 범위를 벗어났습니다."),
     INVALID_INPUT_NICKNAME(4006, "닉네임은 한글로만 입력 가능합니다."),
+    GROUP_ACCESS_SCHOOL_MISMATCH(4007, "같은 학교의 모임만 조회 가능합니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED_ACCESS(4010, "리소스 접근 권한이 없습니다."),

--- a/src/main/java/com/ggang/be/api/facade/CommentFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/CommentFacade.java
@@ -13,7 +13,10 @@ import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.comment.CommentEntity;
+import com.ggang.be.domain.common.SameSchoolValidator;
 import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.global.annotation.Facade;
@@ -29,6 +32,7 @@ public class CommentFacade {
     private final UserEveryGroupService userEveryGroupService;
     private final UserOnceGroupService userOnceGroupService;
     private final UserService userService;
+    private final SameSchoolValidator sameSchoolValidator;
 
     @Transactional
     public WriteCommentResponse writeComment(final long userId, WriteCommentRequest dto) {
@@ -55,10 +59,16 @@ public class CommentFacade {
 
     private ReadCommentGroup readByCase(UserEntity userEntity, boolean isPublic, ReadCommentRequest dto) {
         if(dto.groupType() == GroupType.WEEKLY) {
+            EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(
+                dto.groupId());
+            sameSchoolValidator.isUserReadMySchoolEveryGroup(userEntity, everyGroupEntity);
             isValidEveryGroupCommentAccess(userEntity, isPublic, dto);
             return everyGroupService.readCommentInGroup(userEntity, isPublic, dto.groupId());
         }
         if(dto.groupType() == GroupType.ONCE) {
+            OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(
+                dto.groupId());
+            sameSchoolValidator.isUserReadMySchoolOnceGroup(userEntity, onceGroupEntity);
             isValidOnceGroupCommentAccess(userEntity, isPublic, dto);
             return onceGroupService.readCommentInGroup(userEntity, isPublic, dto.groupId());
         }

--- a/src/main/java/com/ggang/be/api/facade/CommentFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/CommentFacade.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Facade
 @RequiredArgsConstructor
 public class CommentFacade {
+
     private final EveryGroupService everyGroupService;
     private final OnceGroupService onceGroupService;
     private final CommentService commentService;
@@ -45,27 +46,39 @@ public class CommentFacade {
     }
 
     private void writeByCase(WriteCommentRequest dto, CommentEntity commentEntity) {
-        if(dto.groupType() == GroupType.WEEKLY)
+        if (dto.groupType() == GroupType.WEEKLY) {
+            EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(
+                dto.groupId());
+            sameSchoolValidator.isUserReadMySchoolEveryGroup(commentEntity.getUserEntity(),
+                everyGroupEntity);
             everyGroupService.writeCommentInGroup(commentEntity, dto.groupId());
-        if(dto.groupType() == GroupType.ONCE)
+        }
+        if (dto.groupType() == GroupType.ONCE) {
+            OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(
+                dto.groupId());
+            sameSchoolValidator.isUserReadMySchoolOnceGroup(commentEntity.getUserEntity(),
+                onceGroupEntity);
             onceGroupService.writeCommentInGroup(commentEntity, dto.groupId());
+        }
     }
 
-    public ReadCommentResponse readComment(Long userId, final boolean isPublic, ReadCommentRequest dto) {
+    public ReadCommentResponse readComment(Long userId, final boolean isPublic,
+        ReadCommentRequest dto) {
         UserEntity findUserEntity = userService.getUserById(userId);
 
         return ReadCommentResponse.of(readByCase(findUserEntity, isPublic, dto));
     }
 
-    private ReadCommentGroup readByCase(UserEntity userEntity, boolean isPublic, ReadCommentRequest dto) {
-        if(dto.groupType() == GroupType.WEEKLY) {
+    private ReadCommentGroup readByCase(UserEntity userEntity, boolean isPublic,
+        ReadCommentRequest dto) {
+        if (dto.groupType() == GroupType.WEEKLY) {
             EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(
                 dto.groupId());
             sameSchoolValidator.isUserReadMySchoolEveryGroup(userEntity, everyGroupEntity);
             isValidEveryGroupCommentAccess(userEntity, isPublic, dto);
             return everyGroupService.readCommentInGroup(userEntity, isPublic, dto.groupId());
         }
-        if(dto.groupType() == GroupType.ONCE) {
+        if (dto.groupType() == GroupType.ONCE) {
             OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(
                 dto.groupId());
             sameSchoolValidator.isUserReadMySchoolOnceGroup(userEntity, onceGroupEntity);
@@ -75,14 +88,18 @@ public class CommentFacade {
         throw new GongBaekException(ResponseError.BAD_REQUEST);
     }
 
-    private void isValidOnceGroupCommentAccess(UserEntity userEntity, boolean isPublic, ReadCommentRequest dto) {
-        if(!isPublic)
+    private void isValidOnceGroupCommentAccess(UserEntity userEntity, boolean isPublic,
+        ReadCommentRequest dto) {
+        if (!isPublic) {
             userOnceGroupService.isValidCommentAccess(userEntity, dto.groupId());
+        }
     }
 
-    private void isValidEveryGroupCommentAccess(UserEntity userEntity, boolean isPublic, ReadCommentRequest dto) {
-        if(!isPublic)
+    private void isValidEveryGroupCommentAccess(UserEntity userEntity, boolean isPublic,
+        ReadCommentRequest dto) {
+        if (!isPublic) {
             userEveryGroupService.isValidCommentAccess(userEntity, dto.groupId());
+        }
     }
 
 }

--- a/src/main/java/com/ggang/be/api/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GroupFacade.java
@@ -11,6 +11,7 @@ import com.ggang.be.api.mapper.GroupResponseMapper;
 import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.common.SameSchoolValidator;
 import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.constant.WeekDate;
 import com.ggang.be.domain.group.dto.GroupVo;
@@ -50,6 +51,7 @@ public class GroupFacade {
     private final UserService userService;
     private final GongbaekTimeSlotService gongbaekTimeSlotService;
     private final LectureTimeSlotService lectureTimeSlotService;
+    private final SameSchoolValidator sameSchoolValidator;
 
     public GroupResponse getGroupInfo(GroupType groupType, Long groupId, long userId) {
         UserEntity currentUser = userService.getUserById(userId);
@@ -252,10 +254,13 @@ public class GroupFacade {
                 );
     }
 
-    public ReadFillMembersResponse getGroupUsersInfo(ReadFillMembersRequest dto) {
+    public ReadFillMembersResponse getGroupUsersInfo(Long userId, ReadFillMembersRequest dto) {
+        UserEntity findUserEntity = userService.getUserById(userId);
         if (dto.groupType() == GroupType.WEEKLY) {
             EveryGroupEntity findEveryGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(
                     dto.groupId());
+            sameSchoolValidator.isUserReadMySchoolEveryGroup(findUserEntity, findEveryGroupEntity);
+
             List<FillMember> everyGroupUsersInfos = userEveryGroupService.getEveryGroupUsersInfo(
                     ReadFillMembersRequest.toEveryGroupMemberInfo(findEveryGroupEntity));
             return ReadFillMembersResponse.ofEveryGroup(findEveryGroupEntity, everyGroupUsersInfos);
@@ -263,6 +268,8 @@ public class GroupFacade {
         if (dto.groupType() == GroupType.ONCE) {
             OnceGroupEntity findOnceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(
                     dto.groupId());
+            sameSchoolValidator.isUserReadMySchoolOnceGroup(findUserEntity, findOnceGroupEntity);
+
             List<FillMember> onceGroupUserInfos = userOnceGroupService.getOnceGroupUsersInfo(
                     ReadFillMembersRequest.toOnceGroupMemberInfo(findOnceGroupEntity));
             return ReadFillMembersResponse.ofOnceGroup(findOnceGroupEntity, onceGroupUserInfos);

--- a/src/main/java/com/ggang/be/api/group/controller/GroupController.java
+++ b/src/main/java/com/ggang/be/api/group/controller/GroupController.java
@@ -68,8 +68,8 @@ public class GroupController {
     @GetMapping("/fill/members")
     public ResponseEntity<ApiResponse<ReadFillMembersResponse>> getGroupMembers(
         @RequestHeader("Authorization") String token, @RequestBody ReadFillMembersRequest dto) {
-        jwtService.isValidToken(token);
-        return ResponseBuilder.ok(groupFacade.getGroupUsersInfo(dto));
+        Long userId = jwtService.parseTokenAndGetUserId(token);
+        return ResponseBuilder.ok(groupFacade.getGroupUsersInfo(userId, dto));
     }
 
     @GetMapping("/my/groups")

--- a/src/main/java/com/ggang/be/domain/common/SameSchoolValidator.java
+++ b/src/main/java/com/ggang/be/domain/common/SameSchoolValidator.java
@@ -1,0 +1,30 @@
+package com.ggang.be.domain.common;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SameSchoolValidator {
+
+
+    public void isUserReadMySchoolEveryGroup(UserEntity userEntity, EveryGroupEntity everyGroupEntity) {
+        String groupCreatorSchoolName = everyGroupEntity.getUserEntity().getSchool().getSchoolName();
+        String userSchoolName = userEntity.getSchool().getSchoolName();
+        if (!groupCreatorSchoolName.equals(userSchoolName))
+            throw new GongBaekException(ResponseError.GROUP_ACCESS_SCHOOL_MISMATCH);
+    }
+
+
+    public void isUserReadMySchoolOnceGroup(UserEntity userEntity, OnceGroupEntity onceGroupEntity) {
+        String groupCreatorSchoolName = onceGroupEntity.getUserEntity().getSchool().getSchoolName();
+        String userSchoolName = userEntity.getSchool().getSchoolName();
+        if (!groupCreatorSchoolName.equals(userSchoolName))
+            throw new GongBaekException(ResponseError.GROUP_ACCESS_SCHOOL_MISMATCH);
+
+    }
+
+}

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
@@ -4,6 +4,8 @@ import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
 import com.ggang.be.domain.comment.CommentEntity;
+import com.ggang.be.domain.common.SameSchoolValidator;
+import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.group.GroupCommentVoMaker;
 import com.ggang.be.domain.group.GroupVoMaker;
@@ -12,17 +14,17 @@ import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.group.everyGroup.dto.EveryGroupDetail;
 import com.ggang.be.domain.group.everyGroup.dto.ReadEveryGroup;
 import com.ggang.be.domain.group.everyGroup.infra.EveryGroupRepository;
+import com.ggang.be.domain.group.everyGroup.vo.ReadEveryGroupCommentCommonVo;
 import com.ggang.be.domain.group.vo.GroupCommentVo;
 import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
 import com.ggang.be.domain.user.UserEntity;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +35,7 @@ public class EveryGroupServiceImpl implements EveryGroupService {
     private final EveryGroupRepository everyGroupRepository;
     private final GroupVoMaker groupVoMaker;
     private final GroupCommentVoMaker groupCommentVoMaker;
+    private final SameSchoolValidator sameSchoolValidator;
 
     @Override
     public EveryGroupDetail getEveryGroupDetail(final long groupId, final UserEntity userEntity) {
@@ -48,40 +51,44 @@ public class EveryGroupServiceImpl implements EveryGroupService {
 
     @Override
     public ReadEveryGroup getMyRegisteredGroups(UserEntity currentUser, boolean status) {
-        List<EveryGroupEntity> everyGroupEntities = everyGroupRepository.findByUserEntity_Id(currentUser.getId());
+        List<EveryGroupEntity> everyGroupEntities = everyGroupRepository.findByUserEntity_Id(
+            currentUser.getId());
 
-        return ReadEveryGroup.of(groupVoMaker.makeEveryGroup(getGroupsByStatus(everyGroupEntities, status)));
+        return ReadEveryGroup.of(
+            groupVoMaker.makeEveryGroup(getGroupsByStatus(everyGroupEntities, status)));
     }
 
     @Override
     public ReadEveryGroup getActiveEveryGroups(UserEntity currentUser) {
         List<EveryGroupEntity> everyGroupEntities = everyGroupRepository.findAll();
 
-        return ReadEveryGroup.of(groupVoMaker.makeEveryGroup(getRecruitingGroups(everyGroupEntities)));
+        return ReadEveryGroup.of(
+            groupVoMaker.makeEveryGroup(getRecruitingGroups(everyGroupEntities)));
     }
 
     private List<EveryGroupEntity> getRecruitingGroups(List<EveryGroupEntity> everyGroupEntities) {
         return everyGroupEntities.stream()
-                .filter(group -> group.getStatus().isRecruiting())
-                .collect(Collectors.toList());
+            .filter(group -> group.getStatus().isRecruiting())
+            .collect(Collectors.toList());
     }
 
-    private List<EveryGroupEntity> getGroupsByStatus(List<EveryGroupEntity> everyGroupEntities, boolean status) {
+    private List<EveryGroupEntity> getGroupsByStatus(List<EveryGroupEntity> everyGroupEntities,
+        boolean status) {
         if (status) {
             return everyGroupEntities.stream()
-                    .filter(group -> group.getStatus().isActive())
-                    .collect(Collectors.toList());
+                .filter(group -> group.getStatus().isActive())
+                .collect(Collectors.toList());
         } else {
             return everyGroupEntities.stream()
-                    .filter(group -> group.getStatus().isClosed())
-                    .collect(Collectors.toList());
+                .filter(group -> group.getStatus().isClosed())
+                .collect(Collectors.toList());
         }
     }
 
     @Override
     public EveryGroupEntity findEveryGroupEntityByGroupId(long groupId) {
         return everyGroupRepository.findById(groupId).orElseThrow(
-                () -> new GongBaekException(ResponseError.GROUP_NOT_FOUND)
+            () -> new GongBaekException(ResponseError.GROUP_NOT_FOUND)
         );
     }
 
@@ -89,28 +96,35 @@ public class EveryGroupServiceImpl implements EveryGroupService {
     @Transactional
     public void writeCommentInGroup(CommentEntity commentEntity, final long groupId) {
         everyGroupRepository.findById(groupId)
-                .orElseThrow(() -> new GongBaekException(ResponseError.GROUP_NOT_FOUND))
-                .addComment(commentEntity);
+            .orElseThrow(() -> new GongBaekException(ResponseError.GROUP_NOT_FOUND))
+            .addComment(commentEntity);
         log.info("everyGroupEntity add Comment success CommentId was  : {}", commentEntity.getId());
     }
 
     @Override
-    public ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean isPublic, long groupId) {
+    public ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean isPublic,
+        long groupId) {
 
         EveryGroupEntity everyGroupEntity = everyGroupRepository.findById(groupId)
-                .orElseThrow(() -> new GongBaekException(ResponseError.GROUP_NOT_FOUND));
+            .orElseThrow(() -> new GongBaekException(ResponseError.GROUP_NOT_FOUND));
 
         List<CommentEntity> commentEntities = everyGroupEntity
-                .getComments().stream().filter(c -> c.isPublic() == isPublic).toList();
+            .getComments().stream().filter(c -> c.isPublic() == isPublic).toList();
 
         int commentCount = commentEntities.size();
 
-        List<GroupCommentVo> onceGroupCommentVos = groupCommentVoMaker.makeByEveryGroup(
-                userEntity, commentEntities, everyGroupEntity);
+        List<GroupCommentVo> everyGroupCommentVos = groupCommentVoMaker.makeByEveryGroup(
+            userEntity, commentEntities, everyGroupEntity);
 
-        return ReadCommentGroup.of(commentCount, onceGroupCommentVos);
+        ReadEveryGroupCommentCommonVo readEveryGroupCommentCommonVo = ReadEveryGroupCommentCommonVo.of(
+            commentCount,
+            groupId,
+            everyGroupEntity.getStatus());
 
+        return ReadCommentGroup.fromEveryGroup(readEveryGroupCommentCommonVo,
+            everyGroupCommentVos);
     }
+
 
     @Override
     @Transactional
@@ -125,7 +139,8 @@ public class EveryGroupServiceImpl implements EveryGroupService {
 
     @Override
     @Transactional
-    public boolean validateApplyEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity){
+    public boolean validateApplyEveryGroup(UserEntity currentUser,
+        EveryGroupEntity everyGroupEntity) {
         validateAlreadyApplied(currentUser, everyGroupEntity);
         validateHostAccess(currentUser, everyGroupEntity);
         validateGroupFull(everyGroupEntity);
@@ -152,26 +167,27 @@ public class EveryGroupServiceImpl implements EveryGroupService {
 
     @Override
     public void isExistedInTime(RegisterGroupServiceRequest serviceRequest) {
-        if(everyGroupRepository.isInTime
+        if (everyGroupRepository.isInTime
             (serviceRequest.userEntity(), serviceRequest.startTime(), serviceRequest.endTime(),
-                serviceRequest.weekDay(), Status.CLOSED))
+                serviceRequest.weekDay(), Status.CLOSED)) {
             throw new GongBaekException(ResponseError.GROUP_ALREADY_EXIST);
+        }
     }
 
     private void validateAlreadyApplied(UserEntity currentUser, EveryGroupEntity everyGroupEntity) {
-        if(everyGroupEntity.isApply(currentUser)) {
+        if (everyGroupEntity.isApply(currentUser)) {
             throw new GongBaekException(ResponseError.APPLY_ALREADY_EXIST);
         }
     }
 
     private void validateHostAccess(UserEntity currentUser, EveryGroupEntity everyGroupEntity) {
-        if(everyGroupEntity.isHost(currentUser)) {
+        if (everyGroupEntity.isHost(currentUser)) {
             throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
         }
     }
 
     private void validateGroupFull(EveryGroupEntity everyGroupEntity) {
-        if(everyGroupEntity.getCurrentPeopleCount() == everyGroupEntity.getMaxPeopleCount()) {
+        if (everyGroupEntity.getCurrentPeopleCount() == everyGroupEntity.getMaxPeopleCount()) {
             throw new GongBaekException(ResponseError.GROUP_ALREADY_FULL);
         }
     }

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/vo/ReadEveryGroupCommentCommonVo.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/vo/ReadEveryGroupCommentCommonVo.java
@@ -1,0 +1,14 @@
+package com.ggang.be.domain.group.everyGroup.vo;
+
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.constant.Status;
+
+public record ReadEveryGroupCommentCommonVo(int commentCount, long groupId, GroupType groupType,
+                                            Status status) {
+
+    public static ReadEveryGroupCommentCommonVo of(int commentCount, long groupId,
+        Status status) {
+        return new ReadEveryGroupCommentCommonVo(commentCount, groupId, GroupType.WEEKLY, status);
+    }
+
+}

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
@@ -4,6 +4,7 @@ import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
 import com.ggang.be.domain.comment.CommentEntity;
+import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.group.GroupCommentVoMaker;
 import com.ggang.be.domain.group.GroupVoMaker;
@@ -12,6 +13,7 @@ import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.group.onceGroup.dto.OnceGroupDto;
 import com.ggang.be.domain.group.onceGroup.dto.ReadOnceGroup;
 import com.ggang.be.domain.group.onceGroup.infra.OnceGroupRepository;
+import com.ggang.be.domain.group.onceGroup.vo.ReadOnceGroupCommentCommonVo;
 import com.ggang.be.domain.group.vo.GroupCommentVo;
 import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
@@ -102,13 +104,14 @@ public class OnceGroupServiceImpl implements OnceGroupService {
 
         List<CommentEntity> commentEntities = onceGroupEntity
                 .getComments().stream().filter(c -> c.isPublic() == isPublic).toList();
-
         int commentCount = commentEntities.size();
 
         List<GroupCommentVo> onceGroupCommentVos = groupCommentVoMaker.makeByOnceGroup(userEntity,
                 commentEntities, onceGroupEntity);
+        ReadOnceGroupCommentCommonVo vo = ReadOnceGroupCommentCommonVo.of(
+            commentCount, groupId, onceGroupEntity.getStatus());
 
-        return ReadCommentGroup.of(commentCount, onceGroupCommentVos);
+        return ReadCommentGroup.fromOnceGroup(vo, onceGroupCommentVos);
     }
 
     @Override

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/vo/ReadOnceGroupCommentCommonVo.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/vo/ReadOnceGroupCommentCommonVo.java
@@ -1,0 +1,13 @@
+package com.ggang.be.domain.group.onceGroup.vo;
+
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.constant.Status;
+
+public record ReadOnceGroupCommentCommonVo(int commentCount, long groupId, GroupType groupType,
+                                           Status status) {
+
+    public static ReadOnceGroupCommentCommonVo of(int commentCount, long groupId, Status status) {
+        return new ReadOnceGroupCommentCommonVo(commentCount, groupId, GroupType.ONCE, status);
+    }
+
+}

--- a/src/main/java/com/ggang/be/domain/group/vo/GroupCommentVo.java
+++ b/src/main/java/com/ggang/be/domain/group/vo/GroupCommentVo.java
@@ -9,7 +9,7 @@ import com.ggang.be.domain.user.UserEntity;
 import java.time.format.DateTimeFormatter;
 
 public record GroupCommentVo(
-        long groupId, GroupType groupType, long commentId,boolean isWriter,
+        long commentId,boolean isWriter,
         boolean isGroupHost, String nickname, String body, String createdAt
 ) {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
@@ -20,7 +20,7 @@ public record GroupCommentVo(
         UserEntity commentUserEntity = commentEntity.getUserEntity();
         Long creatorId = groupEntity.getUserEntity().getId();
 
-        return new GroupCommentVo(groupEntity.getId(), GroupType.WEEKLY, commentEntity.getId(),
+        return new GroupCommentVo(commentEntity.getId(),
             commentUserEntity.getId().equals(nowUserEntity.getId()),
             commentUserEntity.getId().equals(creatorId),
             commentUserEntity.getNickname(), commentEntity.getBody(),
@@ -33,7 +33,7 @@ public record GroupCommentVo(
         UserEntity commentUserEntity = commentEntity.getUserEntity();
         Long creatorId = groupEntity.getUserEntity().getId();
 
-        return new GroupCommentVo(groupEntity.getId(), GroupType.ONCE, commentEntity.getId(),
+        return new GroupCommentVo(commentEntity.getId(),
             commentUserEntity.getId().equals(nowUserEntity.getId()),
             commentUserEntity.getId().equals(creatorId),
             commentUserEntity.getNickname(), commentEntity.getBody(),

--- a/src/main/java/com/ggang/be/domain/group/vo/ReadCommentGroup.java
+++ b/src/main/java/com/ggang/be/domain/group/vo/ReadCommentGroup.java
@@ -1,10 +1,29 @@
 package com.ggang.be.domain.group.vo;
 
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.constant.Status;
+import com.ggang.be.domain.group.everyGroup.vo.ReadEveryGroupCommentCommonVo;
+import com.ggang.be.domain.group.onceGroup.vo.ReadOnceGroupCommentCommonVo;
 import java.util.List;
 
-public record ReadCommentGroup(int commentCount, List<GroupCommentVo> comments) {
+public record ReadCommentGroup(int commentCount, long groupId, GroupType groupType,
+                               Status groupStatus, List<GroupCommentVo> comments) {
+    public static ReadCommentGroup fromEveryGroup(ReadEveryGroupCommentCommonVo vo,
+        List<GroupCommentVo> comments) {
+        return new ReadCommentGroup(vo.commentCount(),
+            vo.groupId(),
+            vo.groupType(),
+            vo.status(),
+            comments);
+    }
 
-    public static ReadCommentGroup of(int commentCount, List<GroupCommentVo> comments) {
-        return new ReadCommentGroup(commentCount, comments);
+
+    public static ReadCommentGroup fromOnceGroup(ReadOnceGroupCommentCommonVo vo,
+        List<GroupCommentVo> comments) {
+        return new ReadCommentGroup(vo.commentCount(),
+            vo.groupId(),
+            vo.groupType(),
+            vo.status(),
+            comments);
     }
 }

--- a/src/main/java/com/ggang/be/domain/school/SchoolEntity.java
+++ b/src/main/java/com/ggang/be/domain/school/SchoolEntity.java
@@ -25,6 +25,7 @@ public class SchoolEntity extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
+    // TODO : unique 제약 조건 달기!
     private String schoolName;
 
     @Column(nullable = false)

--- a/src/test/java/com/ggang/be/domain/common/SameSchoolValidatorTest.java
+++ b/src/test/java/com/ggang/be/domain/common/SameSchoolValidatorTest.java
@@ -1,7 +1,5 @@
 package com.ggang.be.domain.common;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.group.everyGroup.EveryGroupFixture;
@@ -14,11 +12,7 @@ import com.ggang.be.domain.user.fixture.UserEntityFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class SameSchoolValidatorTest {
 
     private SameSchoolValidator sameSchoolValidator = new SameSchoolValidator();

--- a/src/test/java/com/ggang/be/domain/common/SameSchoolValidatorTest.java
+++ b/src/test/java/com/ggang/be/domain/common/SameSchoolValidatorTest.java
@@ -1,0 +1,84 @@
+package com.ggang.be.domain.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.group.everyGroup.EveryGroupFixture;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.group.onceGroup.OnceGroupFixture;
+import com.ggang.be.domain.school.SchoolEntity;
+import com.ggang.be.domain.school.fixture.SchoolEntityFixture;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.domain.user.fixture.UserEntityFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SameSchoolValidatorTest {
+
+    private SameSchoolValidator sameSchoolValidator = new SameSchoolValidator();
+
+    @Test
+    @DisplayName("내가 주차 그룹을 조회할 때 다른 학교인 경우")
+    void isUserReadDiffSchoolEveryGroup() {
+        //given
+        SchoolEntity test = SchoolEntityFixture.createSchoolName("광운대학교");
+        SchoolEntity test2 = SchoolEntityFixture.createSchoolName("test2");
+        UserEntity fixtureUser = UserEntityFixture.createBySchool(test);
+        EveryGroupEntity testEveryGroup = EveryGroupFixture.createBySchool(test2);
+
+        //when && then
+        Assertions.assertThatThrownBy(() -> sameSchoolValidator.isUserReadMySchoolEveryGroup(fixtureUser, testEveryGroup))
+            .isInstanceOf(GongBaekException.class)
+            .hasMessageContaining("같은 학교의 모임만 조회 가능합니다.");
+    }
+
+    @Test
+    @DisplayName("내 일회성 그룹 조회할 때 다른 학교인 경우")
+    void isUserReadDiffSchoolOnceGroup() {
+        //given
+        SchoolEntity test = SchoolEntityFixture.createSchoolName("광운대학교");
+        SchoolEntity test2 = SchoolEntityFixture.createSchoolName("test2");
+        UserEntity fixtureUser = UserEntityFixture.createBySchool(test);
+        OnceGroupEntity testOnceGroup = OnceGroupFixture.createBySchool(test2);
+
+        //when && then
+        Assertions.assertThatThrownBy(() -> sameSchoolValidator.isUserReadMySchoolOnceGroup(fixtureUser, testOnceGroup))
+            .isInstanceOf(GongBaekException.class)
+            .hasMessageContaining("같은 학교의 모임만 조회 가능합니다.");
+    }
+
+    @Test
+    @DisplayName("내 일회성 그룹 조회할 때 같은 학교인 경우")
+    void isUserReadSameSchoolEveryGroup() {
+        //given
+        SchoolEntity test = SchoolEntityFixture.createSchoolName("test2");
+        SchoolEntity test2 = SchoolEntityFixture.createSchoolName("test2");
+        UserEntity fixtureUser = UserEntityFixture.createBySchool(test);
+        EveryGroupEntity testEveryGroup = EveryGroupFixture.createBySchool(test2);
+
+        //when && then
+        Assertions.assertThatCode(() -> sameSchoolValidator.isUserReadMySchoolEveryGroup(fixtureUser, testEveryGroup))
+            .doesNotThrowAnyException();
+    }
+
+
+    @Test
+    @DisplayName("내 일회성 그룹 조회할 때 다른 학교인 경우")
+    void isUserReadSameSchoolOnceGroup() {
+        //given
+        SchoolEntity test = SchoolEntityFixture.createSchoolName("test2");
+        SchoolEntity test2 = SchoolEntityFixture.createSchoolName("test2");
+        UserEntity fixtureUser = UserEntityFixture.createBySchool(test);
+        OnceGroupEntity testOnceGroup = OnceGroupFixture.createBySchool(test2);
+
+        //when && then
+        Assertions.assertThatCode(() -> sameSchoolValidator.isUserReadMySchoolOnceGroup(fixtureUser, testOnceGroup))
+            .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/ggang/be/domain/group/GroupCommentVoFixture.java
+++ b/src/test/java/com/ggang/be/domain/group/GroupCommentVoFixture.java
@@ -8,10 +8,8 @@ import java.time.format.DateTimeFormatter;
 public class GroupCommentVoFixture {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
 
-    public static GroupCommentVo createGroupCommentOnceVo(long groupId, long commentId,LocalDateTime now) {
+    public static GroupCommentVo createGroupCommentOnceVo(long commentId,LocalDateTime now) {
         return new GroupCommentVo(
-            groupId,
-            GroupType.ONCE,
             commentId,
             true,
             true,
@@ -22,10 +20,8 @@ public class GroupCommentVoFixture {
     }
 
 
-    public static GroupCommentVo createGroupCommentEveryVo(long groupId, long commentId, LocalDateTime now) {
+    public static GroupCommentVo createGroupCommentEveryVo(long commentId, LocalDateTime now) {
         return new GroupCommentVo(
-            groupId,
-            GroupType.WEEKLY,
             commentId,
             true,
             true,

--- a/src/test/java/com/ggang/be/domain/group/everyGroup/EveryGroupFixture.java
+++ b/src/test/java/com/ggang/be/domain/group/everyGroup/EveryGroupFixture.java
@@ -5,7 +5,9 @@ import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.constant.WeekDate;
 import com.ggang.be.domain.gongbaekTImeSlot.GongbaekTimeSlotFixture;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.school.SchoolEntity;
 import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.domain.user.fixture.UserEntityFixture;
 import java.time.LocalDate;
 import java.util.ArrayList;
 
@@ -18,6 +20,23 @@ public class EveryGroupFixture {
                 .schoolMajorName("Software Engineering")
                 .profileImg(1)
                 .build()) // UserEntity 생성
+            .comments(new ArrayList<>()) // 댓글 리스트 (비어있음)
+            .dueDate(LocalDate.of(2024, 1, 1)) // 마감 날짜
+            .gongbaekTimeSlotEntity(GongbaekTimeSlotFixture.getTestGongbaekTimeSlot()) // 공백 시간 슬롯
+            .category(Category.DINING) // 열거형 값으로 가정
+            .coverImg(2) // 커버 이미지
+            .location("Busan") // 위치 정보
+            .status(Status.CLOSED) // 열거형 값으로 가정
+            .maxPeopleCount(15) // 최대 인원
+            .currentPeopleCount(5) // 현재 참여 인원
+            .introduction("This is a sample introduction for EveryGroupEntity.")
+            .title("EveryGroup Weekly Meeting")
+            .build();
+    }
+
+    public static EveryGroupEntity createBySchool(SchoolEntity school){
+        return EveryGroupEntity.builder()
+            .userEntity(UserEntityFixture.createBySchool(school)) // UserEntity 생성
             .comments(new ArrayList<>()) // 댓글 리스트 (비어있음)
             .dueDate(LocalDate.of(2024, 1, 1)) // 마감 날짜
             .gongbaekTimeSlotEntity(GongbaekTimeSlotFixture.getTestGongbaekTimeSlot()) // 공백 시간 슬롯

--- a/src/test/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImplTest.java
+++ b/src/test/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImplTest.java
@@ -72,8 +72,8 @@ class EveryGroupServiceImplTest {
 
         when(everyGroupRepository.findById(1L)).thenReturn(Optional.of(build));
         when(groupCommentVoMaker.makeByEveryGroup(eq(userEntity), eq(commentEntities), any())).thenReturn(List.of(
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 1L, LocalDateTime.now()),
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 2L, LocalDateTime.now())
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L, LocalDateTime.now()),
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L, LocalDateTime.now())
         ));
 
         // when
@@ -102,8 +102,8 @@ class EveryGroupServiceImplTest {
 
         when(everyGroupRepository.findById(1L)).thenReturn(Optional.of(build));
         when(groupCommentVoMaker.makeByEveryGroup(eq(userEntity), eq(commentEntities), eq(build))).thenReturn(List.of(
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 3L, LocalDateTime.now()),
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 4L, LocalDateTime.now())
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L,  LocalDateTime.now()),
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L,  LocalDateTime.now())
         ));
 
         // when

--- a/src/test/java/com/ggang/be/domain/group/onceGroup/OnceGroupFixture.java
+++ b/src/test/java/com/ggang/be/domain/group/onceGroup/OnceGroupFixture.java
@@ -3,7 +3,9 @@ package com.ggang.be.domain.group.onceGroup;
 import com.ggang.be.domain.constant.Category;
 import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.gongbaekTImeSlot.GongbaekTimeSlotFixture;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.school.SchoolEntity;
 import com.ggang.be.domain.user.UserEntity;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -52,4 +54,25 @@ public class OnceGroupFixture {
             .build();
     }
 
+    public static OnceGroupEntity createBySchool(SchoolEntity schoolEntity) {
+        return OnceGroupEntity.builder()
+            .title("Sample Group Title")
+            .introduction("This is a sample group introduction.")
+            .currentPeopleCount(5)
+            .maxPeopleCount(10)
+            .status(Status.CLOSED) // Enum 값으로 가정
+            .location("Seoul")
+            .coverImg(1)
+            .category(Category.DINING) // Enum 값으로 가정
+            .gongbaekTimeSlotEntity(GongbaekTimeSlotFixture.getTestGongbaekTimeSlot()) // 공백 시간 슬롯
+            .groupDate(LocalDate.of(2023, 12, 25)) // 2023년 12월 25일
+            .comments(new ArrayList<>()) // 비어있는 댓글 리스트
+            .userEntity(UserEntity.builder()
+                .nickname("test")
+                .school(schoolEntity)
+                .schoolMajorName("Computer Science")
+                .profileImg(1)
+                .build()) // UserEntity 데이터
+            .build();
+    }
 }

--- a/src/test/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImplTest.java
+++ b/src/test/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImplTest.java
@@ -73,8 +73,8 @@ class OnceGroupServiceImplTest {
 
         when(onceGroupRepository.findById(1L)).thenReturn(Optional.of(build));
         when(groupCommentVoMaker.makeByOnceGroup(eq(testUserEntity), eq(commentEntities), eq(build))).thenReturn(List.of(
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 1L, LocalDateTime.now()),
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 2L, LocalDateTime.now())
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L, LocalDateTime.now()),
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L, LocalDateTime.now())
         ));
 
 
@@ -103,8 +103,8 @@ class OnceGroupServiceImplTest {
 
         when(onceGroupRepository.findById(1L)).thenReturn(Optional.of(build));
         when(groupCommentVoMaker.makeByOnceGroup(eq(testUserEntity), eq(commentEntities), eq(build))).thenReturn(List.of(
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 3L, LocalDateTime.now()),
-            GroupCommentVoFixture.createGroupCommentEveryVo(1L, 4L, LocalDateTime.now())
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L,  LocalDateTime.now()),
+            GroupCommentVoFixture.createGroupCommentEveryVo(1L, LocalDateTime.now())
         ));
 
 

--- a/src/test/java/com/ggang/be/domain/school/fixture/SchoolEntityFixture.java
+++ b/src/test/java/com/ggang/be/domain/school/fixture/SchoolEntityFixture.java
@@ -1,0 +1,13 @@
+package com.ggang.be.domain.school.fixture;
+
+import com.ggang.be.domain.school.SchoolEntity;
+
+public class SchoolEntityFixture {
+
+    public static SchoolEntity createSchoolName(String schoolName) {
+        return SchoolEntity.builder()
+            .schoolName(schoolName)
+            .build();
+    }
+
+}

--- a/src/test/java/com/ggang/be/domain/user/fixture/UserEntityFixture.java
+++ b/src/test/java/com/ggang/be/domain/user/fixture/UserEntityFixture.java
@@ -25,6 +25,20 @@ public class UserEntityFixture {
             .build();
     }
 
+    public static UserEntity createBySchool(SchoolEntity school){
+        return UserEntity.builder()
+            .nickname("test")
+            .school(school)
+            .schoolGrade(3)
+            .gender(Gender.MAN)
+            .introduction("introduction")
+            .mbti(Mbti.INFJ)
+            .profileImg(1)
+            .enterYear(2020)
+            .schoolMajorName("Computer Science")
+            .build();
+    }
+
 
     public static UserEntity create(){
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #78 

### 🎋 작업중인 브랜치
- fix/#78

### 💡 작업내용
- 같은 학교 검증 하는 과정 빠진 할당받았던 api 들에 추가하는 작업 진행

### 🔑 주요 변경사항
- 아래 api 에 group, user 가 같은 id인지 SameSchoolValidator 를 이용하여 검증하였습니다.
   - 모임 참여 멤버 전체 조회 API
   - 댓글 작성 API

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 댓글 작성시 학교가 다른 경우
![image](https://github.com/user-attachments/assets/cf79582d-d311-4c71-ba4a-fe3b7220ca4b)


### 댓글 작성시 학교가 같은 경우
![image](https://github.com/user-attachments/assets/0a35fb7c-2f75-4ee3-b07a-542c95c8e222)


### 모임 참여 맴버 조회 학교가 다른 경우
![image](https://github.com/user-attachments/assets/aa80e592-a682-4120-979f-f470175dbdda)

### 모임 참여 맴버 조회 학교가 같은 경우
![image](https://github.com/user-attachments/assets/66bfbd74-74e2-40a9-bb2e-bf1eea1fc6ce)




closes #78 
