### PR TITLE
[fix] 모임 참여 멤버 전체 조회 API qa 검증 후 발견한 문제 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/facade/GongbaekRequestFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GongbaekRequestFacade.java
@@ -1,9 +1,14 @@
 package com.ggang.be.api.facade;
 
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.dto.RegisterGongbaekRequest;
 import com.ggang.be.api.lectureTimeSlot.service.LectureTimeSlotService;
 import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.IntroductionValidator;
+import com.ggang.be.domain.group.LocationValidator;
+import com.ggang.be.domain.group.TitleValidator;
 import com.ggang.be.domain.timslot.lectureTimeSlot.dto.LectureTimeSlotRequest;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.global.annotation.Facade;
@@ -17,20 +22,49 @@ import lombok.extern.slf4j.Slf4j;
 public class GongbaekRequestFacade {
     private final LectureTimeSlotService  lectureTimeSlotService;
     private final UserService userService;
+    private final LocationValidator locationValidator;
+    private final TitleValidator titleValidator;
+    private final IntroductionValidator introductionValidator;
+
+
 
     public void validateRegisterRequest(Long userId, RegisterGongbaekRequest dto) {
         TimeValidator.isTimeValid(dto.startTime(), dto.endTime());
         isDateValid(dto);
         isWeekDateRight(dto);
+        titleValidator.isGroupTitleValid(dto.groupTitle());
+        locationValidator.isLocationValid(dto.location());
+        introductionValidator.isIntroductionValid(dto.introduction());
+        isValidCoverImg(dto);
+        isValidMaxPeople(dto);
+
 
         UserEntity findUserEntity = userService.getUserById(userId);
 
         checkLectureTimeSlot(dto, findUserEntity);
     }
 
+    private void isValidMaxPeople(RegisterGongbaekRequest dto) {
+        if(dto.maxPeopleCount() < 2 || dto.maxPeopleCount() > 10) {
+            log.error("그룹 maxPeople 검증에 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+    }
+
+
+    private void isValidCoverImg(RegisterGongbaekRequest dto) {
+        if(dto.coverImg()<1 || dto.coverImg()>6) {
+            log.error("그룹 coverImg 검증에 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+    }
+
+
     private void isDateValid(RegisterGongbaekRequest dto) {
-        if(dto.groupType() == GroupType.ONCE)
+        if(dto.groupType() == GroupType.ONCE) {
             TimeValidator.isDateBeforeNow(dto.weekDate());
+            TimeValidator.isSameDate(dto.dueDate(), dto.weekDate());
+        }
         TimeValidator.isDateBeforeNow(dto.dueDate());
     }
 

--- a/src/main/java/com/ggang/be/api/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GroupFacade.java
@@ -328,9 +328,11 @@ public class GroupFacade {
 
     public ReadFillMembersResponse getGroupUsersInfo(Long userId, ReadFillMembersRequest dto) {
         UserEntity findUserEntity = userService.getUserById(userId);
+
         if (dto.groupType() == GroupType.WEEKLY) {
             EveryGroupEntity findEveryGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(
                     dto.groupId());
+            userEveryGroupService.isUserInGroup(findUserEntity, findEveryGroupEntity);
             sameSchoolValidator.isUserReadMySchoolEveryGroup(findUserEntity, findEveryGroupEntity);
 
             List<FillMember> everyGroupUsersInfos = userEveryGroupService.getEveryGroupUsersInfo(
@@ -340,6 +342,8 @@ public class GroupFacade {
         if (dto.groupType() == GroupType.ONCE) {
             OnceGroupEntity findOnceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(
                     dto.groupId());
+
+            userOnceGroupService.isUserInGroup(findUserEntity, findOnceGroupEntity);
             sameSchoolValidator.isUserReadMySchoolOnceGroup(findUserEntity, findOnceGroupEntity);
 
             List<FillMember> onceGroupUserInfos = userOnceGroupService.getOnceGroupUsersInfo(

--- a/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
@@ -21,4 +21,6 @@ public interface UserEveryGroupService {
     void applyEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);
 
     void cancelEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);
+
+    void isUserInGroup(UserEntity findUserEntity, EveryGroupEntity findEveryGroupEntity);
 }

--- a/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
@@ -24,4 +24,6 @@ public interface UserOnceGroupService {
     void cancelOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity);
 
     void isValidCommentAccess(UserEntity userEntity, final long groupId);
+
+    void isUserInGroup(UserEntity findUserEntity, OnceGroupEntity findOnceGroupEntity);
 }

--- a/src/main/java/com/ggang/be/domain/group/IntroductionValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/IntroductionValidator.java
@@ -14,10 +14,6 @@ public class IntroductionValidator {
 
     public void isIntroductionValid(String introduction) {
         log.info("now value is : {}", introduction);
-        if(introduction.contains("\n")) {
-            log.error("소개글에 엔터가 들어가 실패하였습니다.");
-            throw new GongBaekException(ResponseError.BAD_REQUEST);
-        }
         if(!LengthValidator.rangelengthCheck(introduction, 20, 100)) {
             log.error("소개글 길이 검증에 실패하였습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);

--- a/src/main/java/com/ggang/be/domain/group/IntroductionValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/IntroductionValidator.java
@@ -1,0 +1,26 @@
+package com.ggang.be.domain.group;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.global.util.LengthValidator;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class IntroductionValidator {
+
+
+    public void isIntroductionValid(String introduction) {
+        log.info("now value is : {}", introduction);
+        if(introduction.contains("\n")) {
+            log.error("소개글에 엔터가 들어가 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+        if(!LengthValidator.rangelengthCheck(introduction, 20, 100)) {
+            log.error("소개글 길이 검증에 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/ggang/be/domain/group/LocationValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/LocationValidator.java
@@ -1,0 +1,27 @@
+package com.ggang.be.domain.group;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.global.util.LengthValidator;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class LocationValidator {
+
+    private static final Pattern pattern = Pattern.compile("^[가-힣a-zA-Z\s]+$");
+
+    public void isLocationValid(final String value){
+        log.info("now Location value is : {}", value);
+        if(!pattern.matcher(value).matches()) {
+            log.error("그룹 장소글 패턴 검증에 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+        if(!LengthValidator.rangelengthCheck(value, 2, 20)) {
+            log.error("그룹 장소글 길이 검증에 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/ggang/be/domain/group/TitleValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/TitleValidator.java
@@ -1,0 +1,25 @@
+package com.ggang.be.domain.group;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.global.util.LengthValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TitleValidator {
+
+
+    public void isGroupTitleValid(final String title) {
+        log.info("now value is : {}", title);
+        if(title.contains("\n")) {
+            log.error("그룹 제목에 엔터가 들어갔습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+        if(!LengthValidator.rangelengthCheck(title, 2, 20)) {
+            log.error("그룹 제목 길이 검증에 실패하였습니다.");
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
@@ -65,6 +65,14 @@ public class UserEveryGroupServiceImpl implements UserEveryGroupService {
     }
 
     @Override
+    public void isUserInGroup(UserEntity findUserEntity, EveryGroupEntity findEveryGroupEntity) {
+        if (userEveryGroupRepository.findByUserEntityAndEveryGroupEntity(findUserEntity, findEveryGroupEntity).isEmpty()) {
+            log.error("User is not in group");
+            throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    @Override
     public ReadEveryGroup getMyAppliedGroups(UserEntity currentUser, boolean status){
         List<UserEveryGroupEntity> userEveryGroupEntities = getMyEveryGroup(currentUser);
 

--- a/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
@@ -100,6 +100,14 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
         }
     }
 
+    @Override
+    public void isUserInGroup(UserEntity findUserEntity, OnceGroupEntity findOnceGroupEntity) {
+        if (userOnceGroupRepository.findByUserEntityAndOnceGroupEntity(findUserEntity, findOnceGroupEntity).isEmpty()) {
+            log.error("User is not in group");
+            throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
+        }
+    }
+
     private OnceGroupEntity getNearestGroup(List<OnceGroupEntity> groups) {
         return groups.stream()
             .min(Comparator.comparing(OnceGroupEntity::getGroupDate))

--- a/src/main/java/com/ggang/be/global/util/TimeValidator.java
+++ b/src/main/java/com/ggang/be/global/util/TimeValidator.java
@@ -18,8 +18,8 @@ public class TimeValidator {
     }
 
     public static void isTimeValid(double startTime, double endTime){
-        if(startTime < 0 || endTime > 24) {
-            log.error("startTime or endTime is not valid");
+        if(startTime < 9 || endTime > 18) {
+            log.error("startTime {} or endTime {} is not valid", startTime, endTime);
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }
         if(startTime > endTime) {
@@ -31,6 +31,13 @@ public class TimeValidator {
     public static void isDateBeforeNow(LocalDate writeDate){
         if(writeDate.isBefore(LocalDate.now())) {
             log.error("writeDate {} is before now {}", writeDate, LocalDate.now());
+            throw new GongBaekException(ResponseError.BAD_REQUEST);
+        }
+    }
+
+    public static void isSameDate(LocalDate date, LocalDate otherDate) {
+        if(!date.equals(otherDate)) {
+            log.error("localDate {} and otherDate {} is not same", date, otherDate);
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }
     }

--- a/src/main/java/com/ggang/be/global/util/TimeValidator.java
+++ b/src/main/java/com/ggang/be/global/util/TimeValidator.java
@@ -18,11 +18,11 @@ public class TimeValidator {
     }
 
     public static void isTimeValid(double startTime, double endTime){
-        if(startTime < 9 || endTime > 18) {
+        if((startTime < 9 || startTime >= 18) && (endTime > 18 || endTime <= 9)) {
             log.error("startTime {} or endTime {} is not valid", startTime, endTime);
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }
-        if(startTime > endTime) {
+        if(startTime >= endTime) {
             log.error("startTime or endTime is not valid");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }

--- a/src/test/java/com/ggang/be/global/jwt/JwtServiceTest.java
+++ b/src/test/java/com/ggang/be/global/jwt/JwtServiceTest.java
@@ -63,6 +63,7 @@ public class JwtServiceTest {
         }
 
     @Test
+    @DisplayName("토큰 재발급 테스트")
     void reIssueToken() throws InterruptedException {
         //given
         String secret = "abcdefghijklmnopqrstuvwxyz123456abcdefghijklmnopqrstuvwxyz123456";


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #96 

### 🎋 작업중인 브랜치
- fix/#96

### 💡 작업내용
- 모임 참여 멤버 전체 조회 API 모임 참여자만 멤버를 조회할 수 있도록 수정 작업 진행

### 🔑 주요 변경사항
- 모임 참여자인지 아닌지 검증하는 로직 중간에 추가!

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 모임 참여 맴버가 모임 맴버 조회 하였을 경우 - ONCE
![image](https://github.com/user-attachments/assets/15621cee-0f60-4afb-807f-60634125d9a0)

### 모임 참여 맴버가 아닌 사람이 모임 맴버 조회 하였을 경우 - ONCE
![image](https://github.com/user-attachments/assets/897273ca-ff33-49a3-9fb4-1296a9cd740a)


### 모임 참여 맴버가 모임 맴버 조회 하였을 경우 - WEEKLY
![image](https://github.com/user-attachments/assets/9019062c-0952-4046-842c-8a5eef2f047f)


### 모임 참여 맴버가 아닌 사람이 모임 맴버 조회 하였을 경우 - WEEKLY
![image](https://github.com/user-attachments/assets/9d552727-7cae-4bde-9441-01bd92332b0f)


closes #96 
