### PR TITLE
[refactor] 모임 참여 맴버 전체 조회 api weekly, once 분기 처리 registry, strategy 적용해서 진행하기

### DIFF
--- a/src/main/java/com/ggang/be/api/comment/strategy/EveryGroupCommentStrategy.java
+++ b/src/main/java/com/ggang/be/api/comment/strategy/EveryGroupCommentStrategy.java
@@ -1,4 +1,4 @@
-package com.ggang.be.api.comment.facade;
+package com.ggang.be.api.comment.strategy;
 
 import com.ggang.be.api.comment.dto.ReadCommentRequest;
 import com.ggang.be.api.comment.dto.ReadCommentResponse;
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @Strategy
 @RequiredArgsConstructor
-public class EveryGroupCommentStrategyFacade implements CommentStrategy {
+public class EveryGroupCommentStrategy implements CommentStrategy {
 
     private final EveryGroupService everyGroupService;
     private final SameSchoolValidator sameSchoolValidator;

--- a/src/main/java/com/ggang/be/api/comment/strategy/OnceGroupCommentStrategy.java
+++ b/src/main/java/com/ggang/be/api/comment/strategy/OnceGroupCommentStrategy.java
@@ -1,4 +1,4 @@
-package com.ggang.be.api.comment.facade;
+package com.ggang.be.api.comment.strategy;
 
 import com.ggang.be.api.comment.dto.ReadCommentRequest;
 import com.ggang.be.api.comment.dto.ReadCommentResponse;
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @Strategy
 @RequiredArgsConstructor
-public class OnceGroupCommentStrategyFacade implements CommentStrategy {
+public class OnceGroupCommentStrategy implements CommentStrategy {
 
     private final OnceGroupService onceGroupService;
     private final SameSchoolValidator sameSchoolValidator;

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupReadFillMemberStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupReadFillMemberStrategy.java
@@ -1,0 +1,44 @@
+package com.ggang.be.api.group.everyGroup.strategy;
+
+import com.ggang.be.api.group.registry.ReadFillMemberStrategy;
+import com.ggang.be.api.group.dto.ReadFillMembersRequest;
+import com.ggang.be.api.group.dto.ReadFillMembersResponse;
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
+import com.ggang.be.domain.common.SameSchoolValidator;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.domain.userEveryGroup.dto.FillMember;
+import com.ggang.be.global.annotation.Strategy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+
+@Strategy
+@RequiredArgsConstructor
+public class EveryGroupReadFillMemberStrategy implements ReadFillMemberStrategy {
+
+    private final EveryGroupService everyGroupService;
+    private final UserEveryGroupService userEveryGroupService;
+    private final SameSchoolValidator sameSchoolValidator;
+
+    @Override
+    public boolean support(GroupType groupType) {
+        return groupType == GroupType.WEEKLY;
+    }
+
+    @Override
+    public ReadFillMembersResponse getGroupUsersInfo(UserEntity findUserEntity, ReadFillMembersRequest dto) {
+        EveryGroupEntity findEveryGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(
+            dto.groupId());
+        userEveryGroupService.isUserInGroup(findUserEntity, findEveryGroupEntity);
+        sameSchoolValidator.isUserReadMySchoolEveryGroup(findUserEntity, findEveryGroupEntity);
+
+        List<FillMember> everyGroupUsersInfos = userEveryGroupService.getEveryGroupUsersInfo(
+            ReadFillMembersRequest.toEveryGroupMemberInfo(findEveryGroupEntity));
+        return ReadFillMembersResponse.ofEveryGroup(findEveryGroupEntity, everyGroupUsersInfos);
+    }
+
+
+}

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupReadFillMemberStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupReadFillMemberStrategy.java
@@ -1,0 +1,45 @@
+package com.ggang.be.api.group.onceGroup.strategy;
+
+import com.ggang.be.api.group.registry.ReadFillMemberStrategy;
+import com.ggang.be.api.group.dto.ReadFillMembersRequest;
+import com.ggang.be.api.group.dto.ReadFillMembersResponse;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.common.SameSchoolValidator;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.domain.userEveryGroup.dto.FillMember;
+import com.ggang.be.global.annotation.Strategy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+
+@Strategy
+@RequiredArgsConstructor
+public class OnceGroupReadFillMemberStrategy implements ReadFillMemberStrategy {
+
+    private final OnceGroupService onceGroupService;
+    private final UserOnceGroupService userOnceGroupService;
+    private final SameSchoolValidator sameSchoolValidator;
+
+    @Override
+    public boolean support(GroupType groupType) {
+        return groupType == GroupType.ONCE;
+    }
+
+    @Override
+    public ReadFillMembersResponse getGroupUsersInfo(UserEntity findUserEntity, ReadFillMembersRequest dto) {
+        OnceGroupEntity findOnceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(
+            dto.groupId());
+
+        userOnceGroupService.isUserInGroup(findUserEntity, findOnceGroupEntity);
+        sameSchoolValidator.isUserReadMySchoolOnceGroup(findUserEntity, findOnceGroupEntity);
+
+        List<FillMember> everyGroupUsersInfos = userOnceGroupService.getOnceGroupUsersInfo(
+            ReadFillMembersRequest.toOnceGroupMemberInfo(findOnceGroupEntity));
+        return ReadFillMembersResponse.ofOnceGroup(findOnceGroupEntity, everyGroupUsersInfos);
+    }
+
+
+}

--- a/src/main/java/com/ggang/be/api/group/registry/ReadFillMemberStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/ReadFillMemberStrategy.java
@@ -1,0 +1,14 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.group.dto.ReadFillMembersRequest;
+import com.ggang.be.api.group.dto.ReadFillMembersResponse;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.user.UserEntity;
+
+public interface ReadFillMemberStrategy {
+
+    boolean support(GroupType groupType);
+
+    ReadFillMembersResponse getGroupUsersInfo(UserEntity findUserEntity, ReadFillMembersRequest dto);
+
+}

--- a/src/main/java/com/ggang/be/api/group/registry/ReadFillMemberStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/ReadFillMemberStrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Registry;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@Registry
+@RequiredArgsConstructor
+public class ReadFillMemberStrategyRegistry {
+
+    private final List<ReadFillMemberStrategy> strategies;
+
+
+    public ReadFillMemberStrategy getStrategy(GroupType groupType){
+        return strategies.stream()
+            .filter(strategy -> strategy.support(groupType))
+            .findFirst().orElseThrow(() -> new GongBaekException(ResponseError.BAD_REQUEST));
+    }
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #128 

### 🎋 작업중인 브랜치
- refactor/#128

### 💡 작업내용
- 모임 참여 맴버 전체 조회 api weekly, once 분기 처리 registry, strategy 적용해서 진행하기

### 🔑 주요 변경사항
- 모임 참여 맴버 전체 조회 api registry, strategy 적용해서 진행했습니다.
- 회의 결과 facade라는 네이밍을 붙이기보다 strategy에 더 집중하는 것이 좋아 이전에 만들었던 클래스들에 facade 네이밍 없애는 작업 진행했습니다. 

### 🏞 스크린샷

### 유저가 모임에 참여하고 있을 때 - ONCE

![image](https://github.com/user-attachments/assets/2514ca06-6639-43de-93e6-7d71f8ff5b0e)


### 유저가 모임에 참여 안 할 때 - ONCE

![image](https://github.com/user-attachments/assets/00efa09d-4b56-499a-8f98-dab046de57f6)

### 유저가 모임에 참여하고 있을 때 - WEEKLY

![image](https://github.com/user-attachments/assets/04bbe794-103f-4bcd-9289-5d39112a93f7)

### 유저가 모임에 참여 안 할 때 - WEEKLY 

![image](https://github.com/user-attachments/assets/028a217b-bbd2-480a-a217-3ed55fcd7906)


closes #128 
