### PR TITLE
[refactor] 모임 정보 조회 API 클래스 분리

### DIFF
--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupInfoStrategy.java
@@ -8,10 +8,10 @@ import com.ggang.be.domain.common.SameSchoolValidator;
 import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
+@Strategy
 @RequiredArgsConstructor
 public class EveryGroupInfoStrategy implements GroupInfoStrategy {
 

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupInfoStrategy.java
@@ -1,0 +1,32 @@
+package com.ggang.be.api.group.everyGroup.strategy;
+
+import com.ggang.be.api.group.dto.GroupResponse;
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.registry.GroupInfoStrategy;
+import com.ggang.be.api.mapper.GroupResponseMapper;
+import com.ggang.be.domain.common.SameSchoolValidator;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EveryGroupInfoStrategy implements GroupInfoStrategy {
+
+    private final EveryGroupService everyGroupService;
+    private final SameSchoolValidator sameSchoolValidator;
+
+    @Override
+    public boolean supports(GroupType groupType) {
+        return groupType == GroupType.ONCE;
+    }
+
+    @Override
+    public GroupResponse getGroupInfo(Long groupId, UserEntity userEntity){
+        EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(groupId);
+        sameSchoolValidator.isUserReadMySchoolEveryGroup(userEntity, everyGroupEntity);
+        return GroupResponseMapper.fromEveryGroup(everyGroupService.getEveryGroupDetail(groupId, userEntity));
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupInfoStrategy.java
@@ -20,7 +20,7 @@ public class EveryGroupInfoStrategy implements GroupInfoStrategy {
 
     @Override
     public boolean supports(GroupType groupType) {
-        return groupType == GroupType.ONCE;
+        return groupType == GroupType.WEEKLY;
     }
 
     @Override

--- a/src/main/java/com/ggang/be/api/group/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/group/facade/GroupFacade.java
@@ -3,22 +3,10 @@ package com.ggang.be.api.group.facade;
 import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.gongbaekTimeSlot.service.GongbaekTimeSlotService;
-import com.ggang.be.api.group.dto.ActiveGroupsResponse;
-import com.ggang.be.api.group.dto.FillGroupFilterRequest;
-import com.ggang.be.api.group.dto.GroupRequest;
-import com.ggang.be.api.group.dto.GroupResponse;
-import com.ggang.be.api.group.dto.MyGroupResponse;
-import com.ggang.be.api.group.dto.NearestGroupResponse;
-import com.ggang.be.api.group.dto.ReadFillMembersRequest;
-import com.ggang.be.api.group.dto.ReadFillMembersResponse;
-import com.ggang.be.api.group.dto.RegisterGongbaekRequest;
-import com.ggang.be.api.group.dto.RegisterGongbaekResponse;
+import com.ggang.be.api.group.dto.*;
 import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
 import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
-import com.ggang.be.api.group.registry.LatestGroupStrategy;
-import com.ggang.be.api.group.registry.LatestGroupStrategyRegistry;
-import com.ggang.be.api.group.registry.ReadFillMemberStrategy;
-import com.ggang.be.api.group.registry.ReadFillMemberStrategyRegistry;
+import com.ggang.be.api.group.registry.*;
 import com.ggang.be.api.lectureTimeSlot.service.LectureTimeSlotService;
 import com.ggang.be.api.mapper.GroupResponseMapper;
 import com.ggang.be.api.user.service.UserService;
@@ -40,14 +28,15 @@ import com.ggang.be.domain.user.dto.UserInfo;
 import com.ggang.be.domain.userEveryGroup.dto.NearestEveryGroup;
 import com.ggang.be.domain.userOnceGroup.dto.NearestOnceGroup;
 import com.ggang.be.global.annotation.Facade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Transactional;
 
 
 @Facade
@@ -64,23 +53,14 @@ public class GroupFacade {
     private final SameSchoolValidator sameSchoolValidator;
     private final LatestGroupStrategyRegistry latestGroupStrategyRegistry;
     private final ReadFillMemberStrategyRegistry readFillMemberStrategyRegistry;
+    private final GroupInfoStrategyRegistry groupInfoStrategyRegistry;
 
     public GroupResponse getGroupInfo(GroupType groupType, Long groupId, long userId) {
         UserEntity currentUser = userService.getUserById(userId);
 
-        switch (groupType) {
-            case WEEKLY -> {
-                EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(groupId);
-                sameSchoolValidator.isUserReadMySchoolEveryGroup(currentUser, everyGroupEntity);
-                return GroupResponseMapper.fromEveryGroup(everyGroupService.getEveryGroupDetail(groupId, currentUser));
-            }
-            case ONCE -> {
-                OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(groupId);
-                sameSchoolValidator.isUserReadMySchoolOnceGroup(currentUser, onceGroupEntity);
-                return  GroupResponseMapper.fromOnceGroup(onceGroupService.getOnceGroupDetail(groupId, currentUser));
-            }
-            default -> throw new GongBaekException(ResponseError.BAD_REQUEST);
-        }
+        GroupInfoStrategy groupInfoStrategy = groupInfoStrategyRegistry.getGroupInfo(groupType);
+
+        return groupInfoStrategy.getGroupInfo(groupId, currentUser);
     }
 
     public NearestGroupResponse getNearestGroupInfo(long userId) {

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupInfoStrategy.java
@@ -1,0 +1,32 @@
+package com.ggang.be.api.group.onceGroup.strategy;
+
+import com.ggang.be.api.group.dto.GroupResponse;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.GroupInfoStrategy;
+import com.ggang.be.api.mapper.GroupResponseMapper;
+import com.ggang.be.domain.common.SameSchoolValidator;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OnceGroupInfoStrategy implements GroupInfoStrategy {
+
+    private final OnceGroupService onceGroupService;
+    private final SameSchoolValidator sameSchoolValidator;
+
+    @Override
+    public boolean supports(GroupType groupType) {
+        return groupType == GroupType.ONCE;
+    }
+
+    @Override
+    public GroupResponse getGroupInfo(Long groupId, UserEntity userEntity){
+        OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(groupId);
+        sameSchoolValidator.isUserReadMySchoolOnceGroup(userEntity, onceGroupEntity);
+        return GroupResponseMapper.fromOnceGroup(onceGroupService.getOnceGroupDetail(groupId, userEntity));
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupInfoStrategy.java
@@ -8,10 +8,10 @@ import com.ggang.be.domain.common.SameSchoolValidator;
 import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
+@Strategy
 @RequiredArgsConstructor
 public class OnceGroupInfoStrategy implements GroupInfoStrategy {
 

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupReadFillMemberStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupReadFillMemberStrategy.java
@@ -1,9 +1,9 @@
 package com.ggang.be.api.group.onceGroup.strategy;
 
-import com.ggang.be.api.group.registry.ReadFillMemberStrategy;
 import com.ggang.be.api.group.dto.ReadFillMembersRequest;
 import com.ggang.be.api.group.dto.ReadFillMembersResponse;
 import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.ReadFillMemberStrategy;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.common.SameSchoolValidator;
 import com.ggang.be.domain.constant.GroupType;
@@ -11,9 +11,9 @@ import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.userEveryGroup.dto.FillMember;
 import com.ggang.be.global.annotation.Strategy;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 
 @Strategy
 @RequiredArgsConstructor

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceLatestGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceLatestGroupStrategy.java
@@ -7,13 +7,13 @@ import com.ggang.be.domain.group.dto.GroupVo;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.group.onceGroup.dto.OnceGroupVo;
 import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Component
+@Strategy
 @RequiredArgsConstructor
 public class OnceLatestGroupStrategy implements LatestGroupStrategy {
 

--- a/src/main/java/com/ggang/be/api/group/registry/GroupInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/GroupInfoStrategy.java
@@ -1,0 +1,11 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.group.dto.GroupResponse;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.user.UserEntity;
+
+public interface GroupInfoStrategy {
+    boolean supports(GroupType groupType);
+
+    GroupResponse getGroupInfo(Long groupId, UserEntity userEntity);
+}

--- a/src/main/java/com/ggang/be/api/group/registry/GroupInfoStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/GroupInfoStrategyRegistry.java
@@ -3,12 +3,12 @@ package com.ggang.be.api.group.registry;
 import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Registry;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
+@Registry
 @RequiredArgsConstructor
 public class GroupInfoStrategyRegistry {
 

--- a/src/main/java/com/ggang/be/api/group/registry/GroupInfoStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/GroupInfoStrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.GroupType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GroupInfoStrategyRegistry {
+
+    private final List<GroupInfoStrategy> groupStrategies;
+
+    public GroupInfoStrategy getGroupInfo(GroupType groupType) {
+        return groupStrategies.stream()
+                .filter(strategy -> strategy.supports(groupType))
+                .findFirst()
+                .orElseThrow(() -> new GongBaekException(ResponseError.BAD_REQUEST));
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/registry/LatestGroupStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/LatestGroupStrategyRegistry.java
@@ -3,12 +3,12 @@ package com.ggang.be.api.group.registry;
 import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Registry;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
+@Registry
 @RequiredArgsConstructor
 public class LatestGroupStrategyRegistry {
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #134 

### 🎋 작업중인 브랜치
- refactor/#134

### 💡 작업내용
- 모임 정보 조회 API 클래스 분리

### 🔑 주요 변경사항
- 모임 정보 조회 API 클래스 분리
```
public GroupResponse getGroupInfo(GroupType groupType, Long groupId, long userId) {
        UserEntity currentUser = userService.getUserById(userId);

        GroupInfoStrategy groupInfoStrategy = groupInfoStrategyRegistry.getGroupInfo(groupType);

        return groupInfoStrategy.getGroupInfo(groupId, currentUser);
    }
```


### 🏞 스크린샷
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/56412644-87ec-4e91-95f6-e6920a138b1f" />

closes #134 
