### PR TITLE
[refactor] 모임 신청 취소하기 API 클래스 분리

### DIFF
--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/CancelEveryGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/CancelEveryGroupStrategy.java
@@ -1,0 +1,33 @@
+package com.ggang.be.api.group.everyGroup.strategy;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.registry.CancelGroupStrategy;
+import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+@Strategy
+@RequiredArgsConstructor
+public class CancelEveryGroupStrategy implements CancelGroupStrategy {
+    private final EveryGroupService everyGroupService;
+    private final UserEveryGroupService userEveryGroupService;
+
+    @Override
+    public boolean support(GroupType groupType) {
+        return groupType.equals(GroupType.WEEKLY);
+    }
+
+    @Override
+    public void cancelGroup(UserEntity userEntity, GroupRequest request) {
+        EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(request.groupId());
+        if (everyGroupService.validateCancelEveryGroup(userEntity, everyGroupEntity))
+            userEveryGroupService.cancelEveryGroup(userEntity, everyGroupEntity);
+        else throw new GongBaekException(ResponseError.GROUP_CANCEL_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/CancelOnceGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/CancelOnceGroupStrategy.java
@@ -1,0 +1,33 @@
+package com.ggang.be.api.group.onceGroup.strategy;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.CancelGroupStrategy;
+import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+@Strategy
+@RequiredArgsConstructor
+public class CancelOnceGroupStrategy implements CancelGroupStrategy {
+    private final OnceGroupService onceGroupService;
+    private final UserOnceGroupService userOnceGroupService;
+
+    @Override
+    public boolean support(GroupType groupType) {
+        return groupType.equals(GroupType.ONCE);
+    }
+
+    @Override
+    public void cancelGroup(UserEntity userEntity, GroupRequest request) {
+        OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(request.groupId());
+        if (onceGroupService.validateCancelOnceGroup(userEntity, onceGroupEntity))
+            userOnceGroupService.cancelOnceGroup(userEntity, onceGroupEntity);
+        else throw new GongBaekException(ResponseError.GROUP_CANCEL_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/registry/CancelGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/CancelGroupStrategy.java
@@ -1,0 +1,11 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.user.UserEntity;
+
+public interface CancelGroupStrategy {
+    boolean support(GroupType groupType);
+
+    void cancelGroup(UserEntity userEntity, GroupRequest request);
+}

--- a/src/main/java/com/ggang/be/api/group/registry/CancelGroupStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/CancelGroupStrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Registry;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Registry
+@RequiredArgsConstructor
+public class CancelGroupStrategyRegistry {
+    private final List<CancelGroupStrategy> cancelGroupStrategies;
+
+    public CancelGroupStrategy getCancelGroupStrategy(GroupType groupType){
+        return cancelGroupStrategies.stream()
+                .filter(applyGroupStrategy -> applyGroupStrategy.support(groupType))
+                .findFirst()
+                .orElseThrow(() -> new GongBaekException(ResponseError.BAD_REQUEST));
+    }
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #136 

### 🎋 작업중인 브랜치
- refactor/#136

### 💡 작업내용
- 모임 신청 취소하기 API 클래스 분리

### 🔑 주요 변경사항
- 모임 신청 취소하기 API 클래스 분리
```java
@Transactional
    public void cancelMyApplication(Long userId, GroupRequest requestDto) {
        UserEntity findUserEntity = userService.getUserById(userId);

        CancelGroupStrategy cancelGroupStrategy = cancelGroupStrategyRegistry.getCancelGroupStrategy(
                requestDto.groupType()
        );

        cancelGroupStrategy.cancelGroup(findUserEntity, requestDto);
    }
```

### 🏞 스크린샷
<img width="1015" alt="image" src="https://github.com/user-attachments/assets/0b17f1fe-85bf-4622-9673-f000ae3b33e1" />


closes #136 
