### PR TITLE
[refactor] 모임 등록하기 api registry, strategy 이용해 클래스 분리 진행

### DIFF
--- a/src/main/java/com/ggang/be/api/group/dto/PrepareRegisterInfo.java
+++ b/src/main/java/com/ggang/be/api/group/dto/PrepareRegisterInfo.java
@@ -1,0 +1,15 @@
+package com.ggang.be.api.group.dto;
+
+import com.ggang.be.domain.group.dto.RegisterGroupServiceRequest;
+import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
+import com.ggang.be.domain.user.UserEntity;
+
+public record PrepareRegisterInfo(UserEntity findUserEntity,
+                                  GongbaekTimeSlotEntity gongbaekTimeSlotEntity,
+                                  RegisterGroupServiceRequest request) {
+
+    public static PrepareRegisterInfo of(UserEntity findUserEntity, GongbaekTimeSlotEntity gongbaekTimeSlotEntity,
+        RegisterGroupServiceRequest serviceRequest) {
+        return new PrepareRegisterInfo(findUserEntity, gongbaekTimeSlotEntity, serviceRequest);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/RegisterEveryGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/RegisterEveryGroupStrategy.java
@@ -1,0 +1,44 @@
+package com.ggang.be.api.group.everyGroup.strategy;
+
+import com.ggang.be.api.group.dto.PrepareRegisterInfo;
+import com.ggang.be.api.group.dto.RegisterGongbaekResponse;
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.registry.RegisterGroupStrategy;
+import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.dto.RegisterGroupServiceRequest;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+@Strategy
+@RequiredArgsConstructor
+public class RegisterEveryGroupStrategy implements RegisterGroupStrategy {
+
+    private final EveryGroupService everyGroupService;
+    private final UserEveryGroupService userEveryGroupService;
+
+
+    @Override
+    public boolean support(GroupType groupType) {
+        return groupType.equals(GroupType.WEEKLY);
+    }
+
+    @Override
+    public RegisterGongbaekResponse registerGroup(PrepareRegisterInfo prepareRegisterInfo) {
+        UserEntity findUserEntity = prepareRegisterInfo.findUserEntity();
+        RegisterGroupServiceRequest serviceRequest = prepareRegisterInfo.request();
+        GongbaekTimeSlotEntity gongbaekTimeSlotEntity = prepareRegisterInfo.gongbaekTimeSlotEntity();
+
+
+        EveryGroupEntity everyGroupEntity = everyGroupService.registerEveryGroup(serviceRequest,
+            gongbaekTimeSlotEntity);
+        userEveryGroupService.applyEveryGroup(findUserEntity, everyGroupEntity);
+        return RegisterGongbaekResponse.of(
+            everyGroupEntity.getId());
+    }
+
+
+}

--- a/src/main/java/com/ggang/be/api/group/facade/PrepareRegisterGongbaekFacade.java
+++ b/src/main/java/com/ggang/be/api/group/facade/PrepareRegisterGongbaekFacade.java
@@ -1,0 +1,46 @@
+package com.ggang.be.api.group.facade;
+
+import com.ggang.be.api.gongbaekTimeSlot.service.GongbaekTimeSlotService;
+import com.ggang.be.api.group.dto.PrepareRegisterInfo;
+import com.ggang.be.api.group.dto.RegisterGongbaekRequest;
+import com.ggang.be.api.user.service.UserService;
+import com.ggang.be.domain.group.dto.RegisterGroupServiceRequest;
+import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
+import com.ggang.be.domain.timslot.gongbaekTimeSlot.dto.GongbaekTimeSlotRequest;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Facade;
+import lombok.RequiredArgsConstructor;
+
+@Facade
+@RequiredArgsConstructor
+public class PrepareRegisterGongbaekFacade {
+
+    private final UserService userService;
+    private final GongbaekTimeSlotService gongbaekTimeSlotService;
+
+    public PrepareRegisterInfo prepareInfo(Long userId, RegisterGongbaekRequest dto){
+        UserEntity findUserEntity = userService.getUserById(userId);
+
+        GongbaekTimeSlotRequest gongbaekDto = convertDtoToGongbaekDto(dto, findUserEntity);
+        RegisterGroupServiceRequest serviceRequest = convertDtoToServiceDto(dto, findUserEntity);
+
+        GongbaekTimeSlotEntity gongbaekTimeSlotEntity = gongbaekTimeSlotService.registerGongbaekTimeSlot(
+            findUserEntity, gongbaekDto);
+
+        return PrepareRegisterInfo.of(findUserEntity, gongbaekTimeSlotEntity, serviceRequest);
+    }
+
+    private RegisterGroupServiceRequest convertDtoToServiceDto(
+        RegisterGongbaekRequest dto, UserEntity findUserEntity
+    ) {
+        return RegisterGongbaekRequest.toServiceRequest(findUserEntity, dto);
+    }
+
+    private GongbaekTimeSlotRequest convertDtoToGongbaekDto(
+        RegisterGongbaekRequest dto, UserEntity findUserEntity
+    ) {
+        return RegisterGongbaekRequest.toGongbaekTimeSlotRequest(findUserEntity, dto);
+    }
+
+
+}

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/RegisterOnceGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/RegisterOnceGroupStrategy.java
@@ -1,0 +1,41 @@
+package com.ggang.be.api.group.onceGroup.strategy;
+
+import com.ggang.be.api.group.dto.PrepareRegisterInfo;
+import com.ggang.be.api.group.dto.RegisterGongbaekResponse;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.RegisterGroupStrategy;
+import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.group.dto.RegisterGroupServiceRequest;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+@Strategy
+@RequiredArgsConstructor
+public class RegisterOnceGroupStrategy implements RegisterGroupStrategy {
+
+    private final OnceGroupService onceGroupService;
+    private final UserOnceGroupService userOnceGroupService;
+
+    @Override
+    public boolean support(GroupType groupType) {
+        return groupType.equals(GroupType.ONCE);
+    }
+
+    @Override
+    public RegisterGongbaekResponse registerGroup(PrepareRegisterInfo prepareRegisterInfo) {
+        UserEntity findUserEntity = prepareRegisterInfo.findUserEntity();
+        RegisterGroupServiceRequest serviceRequest = prepareRegisterInfo.request();
+        GongbaekTimeSlotEntity gongbaekTimeSlotEntity = prepareRegisterInfo.gongbaekTimeSlotEntity();
+
+        OnceGroupEntity onceGroupEntity = onceGroupService.registerOnceGroup(serviceRequest,
+            gongbaekTimeSlotEntity);
+        userOnceGroupService.applyOnceGroup(findUserEntity, onceGroupEntity);
+        return RegisterGongbaekResponse.of(onceGroupEntity.getId());
+    }
+
+
+}

--- a/src/main/java/com/ggang/be/api/group/registry/RegisterGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/RegisterGroupStrategy.java
@@ -1,0 +1,13 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.group.dto.PrepareRegisterInfo;
+import com.ggang.be.api.group.dto.RegisterGongbaekResponse;
+import com.ggang.be.domain.constant.GroupType;
+
+public interface RegisterGroupStrategy {
+
+    boolean support(GroupType groupType);
+
+
+    RegisterGongbaekResponse registerGroup(PrepareRegisterInfo prepareRegisterInfo);
+}

--- a/src/main/java/com/ggang/be/api/group/registry/RegisterGroupStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/RegisterGroupStrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Registry;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@Registry
+@RequiredArgsConstructor
+public class RegisterGroupStrategyRegistry {
+
+    private final List<RegisterGroupStrategy> registerGroupStrategies;
+
+    public RegisterGroupStrategy getRegisterGroupStrategy(GroupType groupType) {
+        return registerGroupStrategies.stream()
+            .filter(strategy -> strategy.support(groupType))
+            .findFirst()
+            .orElseThrow(() -> new GongBaekException(ResponseError.BAD_REQUEST));
+    }
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #138 

### 🎋 작업중인 브랜치
- refactor/#138

### 💡 작업내용
- 클래스가 너무 커져 registry, strategy 를 이용하여 클래스 분리를 진행한다.

### 🔑 주요 변경사항
- dto 준비 과정도 길어서 다른 facade로 분리하여 진행하였습니다.
- registry, strategy 를 이용해 클래스 분리 진행했습니다.

```java
    @Transactional
    public RegisterGongbaekResponse registerGongbaek(Long userId, RegisterGongbaekRequest dto) {

        PrepareRegisterInfo prepareRegisterInfo = prepareRegisterGongbaekFacade.prepareInfo(userId,
            dto);

        RegisterGroupStrategy registerGroupStrategy = registerGroupStrategyRegistry.getRegisterGroupStrategy(
            dto.groupType());

        return registerGroupStrategy.registerGroup(prepareRegisterInfo);
    }
```

### 🏞 스크린샷
스크린샷을 첨부해주세요.


### ONCE 등록 성공
![image](https://github.com/user-attachments/assets/58bc1924-ab56-4557-a649-bc057328ce2b)


### WEEKLY 등록 성공
![image](https://github.com/user-attachments/assets/50b88497-a5ec-4bc4-9db1-de325f9b7617)



closes #138 
