### PR TITLE
[refactor] 등록자 프로필 조회 API 클래스 분리

### DIFF
--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupUserInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/EveryGroupUserInfoStrategy.java
@@ -1,0 +1,24 @@
+package com.ggang.be.api.group.everyGroup.strategy;
+
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.registry.GroupUserInfoStrategy;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+@Strategy
+@RequiredArgsConstructor
+public class EveryGroupUserInfoStrategy implements GroupUserInfoStrategy {
+
+    private final EveryGroupService everyGroupService;
+
+    @Override
+    public boolean supports(GroupType groupType) {
+        return groupType == GroupType.WEEKLY;
+    }
+
+    @Override
+    public long getGroupUserInfo(long groupId) {
+        return everyGroupService.getEveryGroupRegisterUserId(groupId);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/group/facade/GroupFacade.java
@@ -54,6 +54,7 @@ public class GroupFacade {
     private final GroupInfoStrategyRegistry groupInfoStrategyRegistry;
     private final ApplyGroupStrategyRegistry applyGroupStrategyRegistry;
     private final CancelGroupStrategyRegistry cancelGroupStrategyRegistry;
+    private final GroupUserInfoStrategyRegistry groupUserInfoStrategyRegistry;
 
     public GroupResponse getGroupInfo(GroupType groupType, Long groupId, long userId) {
         UserEntity currentUser = userService.getUserById(userId);
@@ -82,12 +83,9 @@ public class GroupFacade {
     }
 
     public UserInfo getGroupUserInfo(GroupType groupType, Long groupId) {
-        long userId = switch (groupType) {
-            case WEEKLY -> everyGroupService.getEveryGroupRegisterUserId(groupId);
-            case ONCE -> onceGroupService.getOnceGroupRegisterUserId(groupId);
-        };
+        GroupUserInfoStrategy groupUserInfoStrategy = groupUserInfoStrategyRegistry.getGroupUserInfo(groupType);
 
-        return UserInfo.of(userService.getUserById(userId));
+        return UserInfo.of(userService.getUserById(groupUserInfoStrategy.getGroupUserInfo(groupId)));
     }
 
     @Transactional

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupUserInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/OnceGroupUserInfoStrategy.java
@@ -1,0 +1,24 @@
+package com.ggang.be.api.group.onceGroup.strategy;
+
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.GroupUserInfoStrategy;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+@Strategy
+@RequiredArgsConstructor
+public class OnceGroupUserInfoStrategy implements GroupUserInfoStrategy {
+
+    private final OnceGroupService onceGroupService;
+
+    @Override
+    public boolean supports(GroupType groupType) {
+        return groupType == GroupType.ONCE;
+    }
+
+    @Override
+    public long getGroupUserInfo(long groupId) {
+        return onceGroupService.getOnceGroupRegisterUserId(groupId);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/registry/GroupUserInfoStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/GroupUserInfoStrategy.java
@@ -1,0 +1,9 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.domain.constant.GroupType;
+
+public interface GroupUserInfoStrategy {
+    boolean supports(GroupType groupType);
+
+    long getGroupUserInfo(long groupId);
+}

--- a/src/main/java/com/ggang/be/api/group/registry/GroupUserInfoStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/GroupUserInfoStrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Registry;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Registry
+@RequiredArgsConstructor
+public class GroupUserInfoStrategyRegistry {
+
+    private final List<GroupUserInfoStrategy> groupUserInfoStrategies;
+
+    public GroupUserInfoStrategy getGroupUserInfo(GroupType groupType) {
+        return groupUserInfoStrategies.stream()
+                .filter(strategy -> strategy.supports(groupType))
+                .findFirst()
+                .orElseThrow(() -> new GongBaekException(ResponseError.BAD_REQUEST));
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #140 

### 🎋 작업중인 브랜치
- refactor/#140

### 💡 작업내용
- 등록자 프로필 조회 API 클래스 분리

### 🔑 주요 변경사항
- 등록자 프로필 조회 API 클래스 분리
```java
public UserInfo getGroupUserInfo(GroupType groupType, Long groupId) {
        GroupUserInfoStrategy groupUserInfoStrategy = groupUserInfoStrategyRegistry.getGroupUserInfo(groupType);

        return UserInfo.of(userService.getUserById(groupUserInfoStrategy.getGroupUserInfo(groupId)));
    }
```

### 🏞 스크린샷

<img width="877" alt="image" src="https://github.com/user-attachments/assets/5790c756-2bed-46a8-8dfe-b4ca48beddf2" />


closes #140
