### PR TITLE
[refactor] 나의 모임 전체 조회 API 클래스 분리

### DIFF
--- a/src/main/java/com/ggang/be/api/group/GroupVoAggregator.java
+++ b/src/main/java/com/ggang/be/api/group/GroupVoAggregator.java
@@ -1,4 +1,4 @@
-package com.ggang.be.global.util;
+package com.ggang.be.api.group;
 
 import com.ggang.be.domain.group.dto.GroupVo;
 import com.ggang.be.domain.group.everyGroup.dto.EveryGroupVo;

--- a/src/main/java/com/ggang/be/api/group/registry/MyGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/MyGroupStrategy.java
@@ -1,0 +1,13 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.domain.constant.FillGroupType;
+import com.ggang.be.domain.group.dto.GroupVo;
+import com.ggang.be.domain.user.UserEntity;
+
+import java.util.List;
+
+public interface MyGroupStrategy {
+    boolean supports(FillGroupType category);
+
+    List<GroupVo> getGroups(UserEntity userEntity, boolean status);
+}

--- a/src/main/java/com/ggang/be/api/group/registry/MyGroupStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/MyGroupStrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.FillGroupType;
+import com.ggang.be.global.annotation.Registry;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Registry
+@RequiredArgsConstructor
+public class MyGroupStrategyRegistry {
+
+    private final List<MyGroupStrategy> groupStrategies;
+
+    public MyGroupStrategy getGroupStrategy(FillGroupType category) {
+        return groupStrategies.stream()
+                .filter(strategy -> strategy.supports(category))
+                .findFirst()
+                .orElseThrow(() -> new GongBaekException(ResponseError.BAD_REQUEST));
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/registry/RegisterGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/RegisterGroupStrategy.java
@@ -8,6 +8,5 @@ public interface RegisterGroupStrategy {
 
     boolean support(GroupType groupType);
 
-
     RegisterGongbaekResponse registerGroup(PrepareRegisterInfo prepareRegisterInfo);
 }

--- a/src/main/java/com/ggang/be/api/group/strategy/MyApplyGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/strategy/MyApplyGroupStrategy.java
@@ -1,0 +1,36 @@
+package com.ggang.be.api.group.strategy;
+
+import com.ggang.be.api.group.registry.MyGroupStrategy;
+import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
+import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.constant.FillGroupType;
+import com.ggang.be.domain.group.dto.GroupVo;
+import com.ggang.be.domain.group.everyGroup.dto.EveryGroupVo;
+import com.ggang.be.domain.group.onceGroup.dto.OnceGroupVo;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.util.GroupVoAggregator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MyApplyGroupStrategy implements MyGroupStrategy {
+
+    private final UserEveryGroupService userEveryGroupService;
+    private final UserOnceGroupService userOnceGroupService;
+
+    @Override
+    public boolean supports(FillGroupType category) {
+        return category == FillGroupType.APPLY;
+    }
+
+    @Override
+    public List<GroupVo> getGroups(UserEntity userEntity, boolean status) {
+        List<EveryGroupVo> everyGroupResponses = userEveryGroupService.getMyAppliedGroups(userEntity, status).groups();
+        List<OnceGroupVo> onceGroupResponses = userOnceGroupService.getMyAppliedGroups(userEntity, status).groups();
+
+        return GroupVoAggregator.aggregateAndSort(everyGroupResponses, onceGroupResponses);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/strategy/MyApplyGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/strategy/MyApplyGroupStrategy.java
@@ -1,5 +1,6 @@
 package com.ggang.be.api.group.strategy;
 
+import com.ggang.be.api.group.GroupVoAggregator;
 import com.ggang.be.api.group.registry.MyGroupStrategy;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
@@ -8,7 +9,6 @@ import com.ggang.be.domain.group.dto.GroupVo;
 import com.ggang.be.domain.group.everyGroup.dto.EveryGroupVo;
 import com.ggang.be.domain.group.onceGroup.dto.OnceGroupVo;
 import com.ggang.be.domain.user.UserEntity;
-import com.ggang.be.global.util.GroupVoAggregator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/ggang/be/api/group/strategy/MyRegisterGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/strategy/MyRegisterGroupStrategy.java
@@ -1,0 +1,36 @@
+package com.ggang.be.api.group.strategy;
+
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.MyGroupStrategy;
+import com.ggang.be.domain.constant.FillGroupType;
+import com.ggang.be.domain.group.dto.GroupVo;
+import com.ggang.be.domain.group.everyGroup.dto.EveryGroupVo;
+import com.ggang.be.domain.group.onceGroup.dto.OnceGroupVo;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.util.GroupVoAggregator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MyRegisterGroupStrategy implements MyGroupStrategy {
+
+    private final EveryGroupService everyGroupService;
+    private final OnceGroupService onceGroupService;
+
+    @Override
+    public boolean supports(FillGroupType category) {
+        return category == FillGroupType.REGISTER;
+    }
+
+    @Override
+    public List<GroupVo> getGroups(UserEntity userEntity, boolean status) {
+        List<EveryGroupVo> everyGroupResponses = everyGroupService.getMyRegisteredGroups(userEntity, status).groups();
+        List<OnceGroupVo> onceGroupResponses = onceGroupService.getMyRegisteredGroups(userEntity, status).groups();
+
+        return GroupVoAggregator.aggregateAndSort(everyGroupResponses, onceGroupResponses);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/strategy/MyRegisterGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/strategy/MyRegisterGroupStrategy.java
@@ -1,5 +1,6 @@
 package com.ggang.be.api.group.strategy;
 
+import com.ggang.be.api.group.GroupVoAggregator;
 import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
 import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
 import com.ggang.be.api.group.registry.MyGroupStrategy;
@@ -8,7 +9,6 @@ import com.ggang.be.domain.group.dto.GroupVo;
 import com.ggang.be.domain.group.everyGroup.dto.EveryGroupVo;
 import com.ggang.be.domain.group.onceGroup.dto.OnceGroupVo;
 import com.ggang.be.domain.user.UserEntity;
-import com.ggang.be.global.util.GroupVoAggregator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/ggang/be/global/util/GroupVoAggregator.java
+++ b/src/main/java/com/ggang/be/global/util/GroupVoAggregator.java
@@ -1,0 +1,21 @@
+package com.ggang.be.global.util;
+
+import com.ggang.be.domain.group.dto.GroupVo;
+import com.ggang.be.domain.group.everyGroup.dto.EveryGroupVo;
+import com.ggang.be.domain.group.onceGroup.dto.OnceGroupVo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GroupVoAggregator {
+
+    public static List<GroupVo> aggregateAndSort(List<EveryGroupVo> everyGroupResponses, List<OnceGroupVo> onceGroupResponses) {
+        return Stream.concat(
+                        everyGroupResponses.stream().map(GroupVo::fromEveryGroup),
+                        onceGroupResponses.stream().map(GroupVo::fromOnceGroup)
+                )
+                .sorted((group1, group2) -> group2.createdAt().compareTo(group1.createdAt()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #144 

### 🎋 작업중인 브랜치
- refactor/#144

### 💡 작업내용
- 나의 모임 전체 조회 API 클래스 분리

### 🔑 주요 변경사항
- 나의 모임 전체 조회 API 클래스 분리
```java
public List<MyGroupResponse> getMyGroups(long userId, FillGroupFilterRequest filterRequestDto) {
        UserEntity currentUser = userService.getUserById(userId);

        MyGroupStrategy groupStrategy = myGroupStrategyRegistry.getGroupStrategy(filterRequestDto.getFillGroupCategory());

        List<GroupVo> groupResponses = groupStrategy.getGroups(currentUser, filterRequestDto.status());

        return groupResponses.stream()
                .map(MyGroupResponse::fromGroupVo)
                .collect(Collectors.toList());
    }
```

### 🏞 스크린샷
<img width="1012" alt="image" src="https://github.com/user-attachments/assets/ca80870f-db51-483f-a434-48fe846935f7" />


closes #144
