### PR TITLE
[feat] api 시작, 종료 로거를 위한 aop 클래스 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
     // valid
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //aop
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ggang/be/global/aop/LoggingAop.java
+++ b/src/main/java/com/ggang/be/global/aop/LoggingAop.java
@@ -1,0 +1,36 @@
+package com.ggang.be.global.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAop {
+
+    @Before("@within(org.springframework.web.bind.annotation.RestController)")
+    public void methodCall(JoinPoint joinPoint) {
+        HttpServletRequest request =
+            ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        log.info("Start this Api request  {} : {}", request.getMethod(),
+            request.getServletPath());
+        log.info("Entering method : {} ", joinPoint.getSignature().getName());
+    }
+
+    @AfterReturning(pointcut = "@within(org.springframework.web.bind.annotation.RestController)")
+    public void logMethodExit() {
+        HttpServletRequest request =
+            ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        log.info("End this Api request  {} : {}", request.getMethod(), request.getServletPath());
+    }
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #153 

### 🎋 작업중인 브랜치
- feat/#153

### 💡 작업내용
- api logging을 위하여 aop를 적용시켜 시작, 종료 시점에 로깅을 출력하는 방식으로 진행하였습니다.

### 🔑 주요 변경사항
- aop 적용 진행

### 🏞 스크린샷

### 시작 시점

![image](https://github.com/user-attachments/assets/ef5cd9ea-f2db-47ab-9f50-3469d834f7b9)

### 종료 시점

![image](https://github.com/user-attachments/assets/5df9d5c0-adaf-4a8f-964b-2db948c2fd3e)



closes #153 
